### PR TITLE
Check guide GPU implementation speed

### DIFF
--- a/acc/components/optics/guide_baseline.py
+++ b/acc/components/optics/guide_baseline.py
@@ -4,7 +4,7 @@
 
 from math import inf, isnan, tanh, sqrt, ceil
 from numba import cuda
-import numpy as np
+import numpy as np, time
 
 from mcni.AbstractComponent import AbstractComponent
 from mcni.neutron_storage import neutrons_as_npyarr, ndblsperneutron
@@ -199,10 +199,17 @@ class Guide(AbstractComponent):
         Parameters:
         neutrons: a buffer containing the particles
         """
+        t1 = time.time()
         neutron_array = neutrons_as_npyarr(neutrons)
         neutron_array.shape = -1, ndblsperneutron
+        t2 = time.time()
         call_process(*self._params, neutron_array)
+        t3 = time.time()
         good = neutron_array[:, -1]>0
         neutrons.resize(int(good.sum()), neutrons[0])
         neutrons.from_npyarr(neutron_array[good])
+        t4 = time.time()
+        print("prepare input array: ", t2-t1)
+        print("call_process: ", t3-t2)
+        print("prepare output neutrons: ", t4-t3)
         return neutrons

--- a/tests/components/optics/check_guide_speed.py
+++ b/tests/components/optics/check_guide_speed.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import os, numpy as np, time
+thisdir = os.path.dirname(__file__)
+
+def test():
+    from mcni.neutron_storage import load
+    neutrons = load('data/before_guide.mcv')
+    from mcvine.acc.components.optics import guide_baseline
+    g = guide_baseline.Guide(
+        name = 'guide',
+        w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=10,
+        R0=0.99, Qc=0.0219, alpha=6.07, m=3, W=0.003,
+    )
+    t1 = time.time()
+    g.process(neutrons)
+    print("GPU processing time:", time.time()-t1)
+
+    neutrons = load('data/before_guide.mcv')
+    import mcvine.components as mc
+    g = mc.optics.Guide(
+        name = 'guide',
+        w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=10,
+        R0=0.99, Qc=0.0219, alpha=6.07, m=3, W=0.003,
+    )
+    t1 = time.time()
+    g.process(neutrons)
+    print("CPU processing time:", time.time()-t1)
+    return
+
+if __name__ == '__main__': test()

--- a/tests/components/optics/guide_instrument.py
+++ b/tests/components/optics/guide_instrument.py
@@ -6,7 +6,10 @@ from mcni import rng_seed
 def seed(): return 0
 rng_seed.seed = seed
 
-def instrument(guide_mod=None, guide_factory=None, save_neutrons_after_guide=False):
+def instrument(
+        guide_mod=None, guide_factory=None,
+        save_neutrons_before_guide=False, save_neutrons_after_guide=False,
+):
     instrument = mcvine.instrument()
     source = mc.sources.Source_simple(
         name = 'source',
@@ -15,6 +18,9 @@ def instrument(guide_mod=None, guide_factory=None, save_neutrons_after_guide=Fal
         Lambda0 = 10., dLambda = 9.5,
     )
     instrument.append(source, position=(0,0,0.))
+    if save_neutrons_before_guide:
+        before_guide = mc.monitors.NeutronToStorage(name='before_guide', path='before_guide.mcv')
+        instrument.append(before_guide, position=(0, 0, 1.))
     if guide_mod:
         import importlib
         mod = importlib.import_module(guide_mod)

--- a/tests/components/optics/save_neutrons_before_guide.py
+++ b/tests/components/optics/save_neutrons_before_guide.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+import os, shutil, time
+from mcvine import run_script
+
+thisdir = os.path.dirname(__file__)
+interactive = False
+
+
+def main():
+    num_neutrons = int(1e8)
+    # Run the mcvine instrument first
+    instr = os.path.join(thisdir, "guide_instrument.py")
+    mcvine_outdir = 'out.save_neutrons_before_guide'
+    if os.path.exists(mcvine_outdir):
+        shutil.rmtree(mcvine_outdir)
+    run_script.run1(
+        instr, mcvine_outdir,
+        ncount=num_neutrons, buffer_size=num_neutrons,
+        guide_factory = "mcvine.components.optics.Guide",
+        save_neutrons_before_guide=True,
+        save_neutrons_after_guide=False,
+        overwrite_datafiles=True)
+    return
+
+if __name__ == '__main__': main()


### PR DESCRIPTION
* Save 1e8 neutrons before guide in a file. Those neutrons were generated by Source_simple
* Call `process` method of `mcvine.components.optics.Guide` and `mcvine.acc.optics.guide_baseline.Guide` and compare execution time