### PR TITLE
Add type annotations to CUDA functions in straight guide and drop to 32-bit precision.

### DIFF
--- a/acc/components/optics/guide.py
+++ b/acc/components/optics/guide.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 by UT-Battelle, LLC.
 
 from math import ceil, sqrt, tanh
-from numba import cuda
+from numba import cuda, float64, void
 from time import time
 
 from mcni.AbstractComponent import AbstractComponent
@@ -12,7 +12,8 @@ from mcni.utils.conversion import V2K
 
 category = 'optics'
 
-@cuda.jit(device=True, inline=True)
+@cuda.jit(float64(float64, float64, float64, float64, float64, float64),
+          device=True, inline=True)
 def calc_reflectivity(Q, R0, Qc, alpha, m, W):
     """
     Calculate the mirror reflectivity for a neutron.
@@ -33,7 +34,10 @@ def calc_reflectivity(Q, R0, Qc, alpha, m, W):
 max_bounces = 100000
 
 
-@cuda.jit(device=True)
+@cuda.jit(void(float64, float64, float64, float64, float64,
+               float64, float64, float64, float64, float64,
+               float64[:]),
+          device=True)
 def propagate(
         ww, hh, hw1, hh1, l,
         R0, Qc, alpha, m, W,
@@ -123,7 +127,9 @@ def propagate(
     in_neutron[-1] = prob
 
 
-@cuda.jit
+@cuda.jit(void(float64, float64, float64, float64, float64,
+               float64, float64, float64, float64, float64,
+               float64[:, :]))
 def process_kernel(
         ww, hh, hw1, hh1, l,
         R0, Qc, alpha, m, W,


### PR DESCRIPTION
Adds explicit rather than inferred type signatures to make it easier to experiment with 32-bit imprecision. With this in, all one need do for such an experiment is:

1. Change all the `float64` to `float32`.
2. Before taking `t2` and after taking `t3`, use `neutron_array.astype(np.float32)` and `neutron_array.astype(np.float64)` to convert the array of neutrons.
3. Check the types using something like,
```python
with open("/tmp/types", "w") as out:
    process_kernel.inspect_types(file=out)
```