### PR TITLE
ComponentBase refactor

### DIFF
--- a/acc/components/ComponentBase.py
+++ b/acc/components/ComponentBase.py
@@ -6,7 +6,6 @@ Requirement for a component
 * `propagate` method
   - first argument: `neutron`
   - other args: match comp.propagate_params
-* at the end of the module, register the propagate method
 """
 import numpy as np
 import numba
@@ -35,6 +34,8 @@ class Curator(type):
         return x
 
 def change_floattype(newtype):
+    # do we really need each component type to have individual floattype
+    # or one floattype for the base class is enough?
     ComponentBase._floattype = newtype
     for c in Curator.components:
         c.change_floattype(newtype)
@@ -42,11 +43,6 @@ def change_floattype(newtype):
 class ComponentBase(AbstractComponent, metaclass=Curator):
 
     _floattype = "float64"
-
-    def __init__(self, subcls, floattype="float64"):
-        # self.floattype = str(floattype)
-        # subcls.propagate = subcls.register_propagate_method(subcls.propagate)
-        return
 
     propagate_params = ()
 
@@ -66,13 +62,6 @@ class ComponentBase(AbstractComponent, metaclass=Curator):
     def change_floattype(cls, newtype):
         cls._floattype = newtype
         cls.propagate = cls.register_propagate_method(cls.propagate)
-    """
-    @floattype.setter
-    def floattype(self, value):
-        if value != "float64" and value != "float32":
-            raise ValueError("Component float type must be 'float64' or 'float32'")
-        self.__class__._floattype = value
-    """
 
     @classmethod
     def get_floattype(cls):

--- a/acc/components/ComponentBase.py
+++ b/acc/components/ComponentBase.py
@@ -49,6 +49,11 @@ class ComponentBase(AbstractComponent, metaclass=abc.ABCMeta):
             raise ValueError("Component float type must be 'float64' or 'float32'")
         self.__class__._floattype = value
 
+    @classmethod
+    def get_floattype(cls):
+        # TODO: fix this to use a class property metaclass?
+        return cls._floattype
+
     def get_numpy_floattype(self):
         return getattr(np, self.__class__._floattype)
 

--- a/acc/components/ComponentBase.py
+++ b/acc/components/ComponentBase.py
@@ -22,10 +22,12 @@ from numba.cuda.compiler import Dispatcher, DeviceFunction
 
 class ComponentBase(AbstractComponent, metaclass=abc.ABCMeta):
 
-    _floattype = None
+    _floattype = "float64"
 
-    def __init__(self, floattype="float64"):
+    def __init__(self, subcls, floattype="float64"):
         self.floattype = str(floattype)
+
+        subcls.propagate = subcls.register_propagate_method(subcls.propagate)
 
     propagate_params = ()
 
@@ -101,6 +103,11 @@ class ComponentBase(AbstractComponent, metaclass=abc.ABCMeta):
 
     @classmethod
     def register_propagate_method(cls, propagate):
+        if not isinstance(propagate, DeviceFunction):
+            raise RuntimeError(
+                "invalid propagate function registered, "
+                "does propagate have a signature defined?")
+
         args = propagate.args
 
         # reconstruct the numba args with the correct floattype

--- a/acc/components/StochasticComponentBase.py
+++ b/acc/components/StochasticComponentBase.py
@@ -35,8 +35,9 @@ class StochasticComponentBase(base):
 
     @classmethod
     def register_propagate_method(cls, propagate):
-        cls.process_kernel = make_process_kernel(propagate)
-        return
+        new_propagate = cls._adjust_propagate_type(propagate)
+        cls.process_kernel = make_process_kernel(new_propagate)
+        return new_propagate
 
 
 def make_process_kernel(propagate):

--- a/acc/components/monitors/divpos_monitor.py
+++ b/acc/components/monitors/divpos_monitor.py
@@ -4,10 +4,11 @@
 category = 'monitors'
 
 import math
-from numba import cuda
+from numba import cuda, void, int64
 import numba as nb, numpy as np
 from mcni.utils.conversion import V2K, SE2V, K2V
 from ...config import get_numba_floattype, get_numpy_floattype
+from ...neutron import absorb, prop_z0
 NB_FLOAT = get_numba_floattype()
 RAD2DEG = 180./math.pi
 
@@ -21,6 +22,7 @@ class DivPos_monitor(base):
             maxdiv=2.,
             npos=20., ndiv=20.,
             filename = "divpos.h5",
+            **kwargs
     ):
         """
         Initialize this Source_simple component.
@@ -33,6 +35,8 @@ class DivPos_monitor(base):
         yheight : float
             Width in meter
         """
+        super().__init__(__class__, **kwargs)
+        
         self.name = name
         self.filename = filename
         if xwidth > 0:
@@ -62,33 +66,32 @@ class DivPos_monitor(base):
             data=self.out_p.T*scale_factor,
             errors=self.out_p2.T*scale_factor*scale_factor)
 
-
-from ...neutron import absorb, prop_z0
-
-@cuda.jit(device=True)
-def propagate(
-        neutron,
-        xmin, xmax, ymin, ymax, xwidth, yheight, maxdiv,
-        npos, ndiv,
-        out_N, out_p, out_p2
-):
-    t0 = neutron[-2]
-    x,y,z, t = prop_z0(neutron)
-    if t0>t:
+    @cuda.jit(
+        void(NB_FLOAT[:], NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+             NB_FLOAT, NB_FLOAT, int64, int64, NB_FLOAT[:, :], NB_FLOAT[:, :],
+             NB_FLOAT[:, :]), device=True)
+    def propagate(
+            neutron,
+            xmin, xmax, ymin, ymax, xwidth, yheight, maxdiv,
+            npos, ndiv,
+            out_N, out_p, out_p2
+    ):
+        t0 = neutron[-2]
+        x,y,z, t = prop_z0(neutron)
+        if t0>t:
+            return
+        p = neutron[-1]
+        vx,vy,vz = neutron[3:6]
+        #
+        if x<=xmin or x>=xmax or y<=ymin or y>=ymax:
+            return
+        div = math.atan(vx/vz)*RAD2DEG
+        if div>=maxdiv or div<=-maxdiv:
+            return
+        ix = int(math.floor( (x-xmin)/(xmax-xmin)*npos ))
+        idiv = int(math.floor( (div+maxdiv)/(2*maxdiv)*ndiv ))
+        cuda.atomic.add(out_N, (idiv,ix), 1)
+        cuda.atomic.add(out_p, (idiv,ix), p)
+        cuda.atomic.add(out_p2, (idiv,ix), p*p)
         return
-    p = neutron[-1]
-    vx,vy,vz = neutron[3:6]
-    #
-    if x<=xmin or x>=xmax or y<=ymin or y>=ymax:
-        return
-    div = math.atan(vx/vz)*RAD2DEG
-    if div>=maxdiv or div<=-maxdiv:
-        return
-    ix = int(math.floor( (x-xmin)/(xmax-xmin)*npos ))
-    idiv = int(math.floor( (div+maxdiv)/(2*maxdiv)*ndiv ))
-    cuda.atomic.add(out_N, (idiv,ix), 1)
-    cuda.atomic.add(out_p, (idiv,ix), p)
-    cuda.atomic.add(out_p2, (idiv,ix), p*p)
-    return
 
-DivPos_monitor.register_propagate_method(propagate)

--- a/acc/components/monitors/divpos_monitor.py
+++ b/acc/components/monitors/divpos_monitor.py
@@ -35,8 +35,6 @@ class DivPos_monitor(base):
         yheight : float
             Width in meter
         """
-        super().__init__(__class__, **kwargs)
-        
         self.name = name
         self.filename = filename
         if xwidth > 0:

--- a/acc/components/monitors/wavelength_monitor.py
+++ b/acc/components/monitors/wavelength_monitor.py
@@ -4,10 +4,11 @@
 category = 'monitors'
 
 import math
-from numba import cuda
+from numba import cuda, void, int64
 import numba as nb, numpy as np
 from mcni.utils.conversion import V2K
 from ...config import get_numba_floattype, get_numpy_floattype
+from ...neutron import absorb, prop_z0
 NB_FLOAT = get_numba_floattype()
 
 from .MonitorBase import MonitorBase as base
@@ -19,7 +20,10 @@ class Wavelength_monitor(base):
             xwidth=0., yheight=0.,
             Lmin=0., Lmax=10., nchan=200,
             filename = "IL.h5",
+            **kwargs
     ):
+        super().__init__(__class__, **kwargs)
+
         self.name = name
         self.filename = filename
         if xwidth > 0:
@@ -47,33 +51,31 @@ class Wavelength_monitor(base):
             data=self.out_p*scale_factor,
             errors=self.out_p2*scale_factor*scale_factor)
 
-
-from ...neutron import absorb, prop_z0
-
-@cuda.jit(device=True)
-def propagate(
-        neutron,
-        xmin, xmax, ymin, ymax,
-        Lmin, Lmax, nchan,
-        out_N, out_p, out_p2
-):
-    t0 = neutron[-2]
-    x,y,z, t = prop_z0(neutron)
-    if t0>t:
+    @cuda.jit(
+        void(NB_FLOAT[:], NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+             NB_FLOAT, int64, NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:]),
+        device=True)
+    def propagate(
+            neutron,
+            xmin, xmax, ymin, ymax,
+            Lmin, Lmax, nchan,
+            out_N, out_p, out_p2
+    ):
+        t0 = neutron[-2]
+        x,y,z, t = prop_z0(neutron)
+        if t0>t:
+            return
+        p = neutron[-1]
+        vx,vy,vz = neutron[3:6]
+        #
+        if x<=xmin or x>=xmax or y<=ymin or y>=ymax:
+            return
+        v = math.sqrt(vx*vx+vy*vy+vz*vz)
+        L = 2*math.pi/(v*V2K)
+        if L<=Lmin or L>=Lmax:
+            return
+        iL = int(math.floor( (L-Lmin)/(Lmax-Lmin)*nchan ))
+        cuda.atomic.add(out_N, iL, 1)
+        cuda.atomic.add(out_p, iL, p)
+        cuda.atomic.add(out_p2, iL, p*p)
         return
-    p = neutron[-1]
-    vx,vy,vz = neutron[3:6]
-    #
-    if x<=xmin or x>=xmax or y<=ymin or y>=ymax:
-        return
-    v = math.sqrt(vx*vx+vy*vy+vz*vz)
-    L = 2*math.pi/(v*V2K)
-    if L<=Lmin or L>=Lmax:
-        return
-    iL = int(math.floor( (L-Lmin)/(Lmax-Lmin)*nchan ))
-    cuda.atomic.add(out_N, iL, 1)
-    cuda.atomic.add(out_p, iL, p)
-    cuda.atomic.add(out_p2, iL, p*p)
-    return
-
-Wavelength_monitor.register_propagate_method(propagate)

--- a/acc/components/monitors/wavelength_monitor.py
+++ b/acc/components/monitors/wavelength_monitor.py
@@ -22,8 +22,6 @@ class Wavelength_monitor(base):
             filename = "IL.h5",
             **kwargs
     ):
-        super().__init__(__class__, **kwargs)
-
         self.name = name
         self.filename = filename
         if xwidth > 0:

--- a/acc/components/optics/arm.py
+++ b/acc/components/optics/arm.py
@@ -9,28 +9,20 @@ category = 'optics'
 from ...config import get_numba_floattype
 NB_FLOAT = get_numba_floattype()
 
-@cuda.jit(
-    void(
-        NB_FLOAT[:]
-    ), device=True
-)
-def propagate(
-        in_neutron
-):
-    pass
-
 
 from ..ComponentBase import ComponentBase
 class Arm(ComponentBase):
 
     def __init__(
-            self, name):
+            self, name, **kwargs):
         """
         Initialize this Arm component.
 
         Parameters:
         name (str): the name of this component
         """
+        super().__init__(__class__, **kwargs)
+
         self.name = name
         self.propagate_params = ()
 
@@ -40,5 +32,13 @@ class Arm(ComponentBase):
         neutrons[0] = mcni.neutron(r=(0, 0, -1), v=(0, 0, 1), prob=1, time=0)
         self.process(neutrons)
 
+    @cuda.jit(
+        void(
+            NB_FLOAT[:]
+        ), device=True
+    )
+    def propagate(
+            in_neutron
+    ):
+        pass
 
-Arm.register_propagate_method(propagate)

--- a/acc/components/optics/beamstop.py
+++ b/acc/components/optics/beamstop.py
@@ -13,64 +13,12 @@ NB_FLOAT = get_numba_floattype()
 category = 'optics'
 
 
-@cuda.jit(
-    void(
-        NB_FLOAT[:],
-        NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
-    ), device=True
-)
-def propagate(
-        neutron,
-        xmin, xmax, ymin, ymax, radius_squared, cut
-):
-    x, y, z, vx, vy, vz = neutron[:6]
-
-    # check that neutron reaches z==0
-    if z < 0 and vz <= 0 or z > 0 and vz >= 0:
-        # absorb(neutron)
-        return
-
-    t, prob = neutron[-2:]
-
-    # check that neutron weight makes the cut
-    if prob < cut:
-        absorb(neutron)
-        return
-
-    # bring neutron to z==0
-    if z != 0:
-        dt = -z / vz
-        x += vx * dt
-        y += vy * dt
-        t += dt
-
-    # check that neutron is not blocked by beamstop
-    if radius_squared != 0:
-        if x * x + y * y <= radius_squared:
-            absorb(neutron)
-            return
-    else:
-        if xmin <= x <= xmax and ymin <= y <= ymax:
-            absorb(neutron)
-            return
-
-    # neutron is not blocked by beamstop
-    neutron[:2] = x, y
-    neutron[2] = 0.
-    neutron[-2] = t
-
-
-@cuda.jit
-def propagate_kernel(beamstop_nature, neutron):
-    (xmin, xmax, ymin, ymax, radius_squared, cut) = beamstop_nature
-    propagate(neutron, xmin, xmax, ymin, ymax, radius_squared, cut)
-
-
 class Beamstop(ComponentBase):
 
     def __init__(
             self, name,
-            xmin=0, xmax=0, ymin=0, ymax=0, radius=0, cut=0, width=0, height=0):
+            xmin=0, xmax=0, ymin=0, ymax=0, radius=0, cut=0, width=0, height=0,
+            **kwargs):
         """
         Initialize this beamstop component.
         The beamstop is at z==0.
@@ -93,6 +41,8 @@ class Beamstop(ComponentBase):
         width (m): sets xmin and xmax to a width centered on x==0
         height (m): sets ymin and ymax to a width centered on y==0
         """
+        super().__init__(__class__, **kwargs)
+
         self.name = name
 
         # Check and process the arguments.
@@ -122,5 +72,49 @@ class Beamstop(ComponentBase):
             r=(x_edge * 2, 0, -1), v=(0, 0, 1), prob=1, time=0)
         self.process(neutrons)
 
+    @cuda.jit(
+        void(
+            NB_FLOAT[:],
+            NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+        ), device=True
+    )
+    def propagate(
+            neutron,
+            xmin, xmax, ymin, ymax, radius_squared, cut
+    ):
+        x, y, z, vx, vy, vz = neutron[:6]
 
-Beamstop.register_propagate_method(propagate)
+        # check that neutron reaches z==0
+        if z < 0 and vz <= 0 or z > 0 and vz >= 0:
+            # absorb(neutron)
+            return
+
+        t, prob = neutron[-2:]
+
+        # check that neutron weight makes the cut
+        if prob < cut:
+            absorb(neutron)
+            return
+
+        # bring neutron to z==0
+        if z != 0:
+            dt = -z / vz
+            x += vx * dt
+            y += vy * dt
+            t += dt
+
+        # check that neutron is not blocked by beamstop
+        if radius_squared != 0:
+            if x * x + y * y <= radius_squared:
+                absorb(neutron)
+                return
+        else:
+            if xmin <= x <= xmax and ymin <= y <= ymax:
+                absorb(neutron)
+                return
+
+        # neutron is not blocked by beamstop
+        neutron[:2] = x, y
+        neutron[2] = 0.
+        neutron[-2] = t
+

--- a/acc/components/optics/guide.py
+++ b/acc/components/optics/guide.py
@@ -41,8 +41,6 @@ class Guide(ComponentBase):
         m: m-value of material (0 is complete absorption)
         W: width of supermirror cutoff
         """
-        super().__init__(__class__, **kwargs)
-
         self.name = name
         ww = .5*(w2-w1); hh = .5*(h2 - h1)
         hw1 = 0.5*w1; hh1 = 0.5*h1

--- a/acc/components/optics/guide.py
+++ b/acc/components/optics/guide.py
@@ -15,101 +15,6 @@ from ._guide_utils import calc_reflectivity
 from ...neutron import absorb
 
 max_bounces = 100000
-@cuda.jit(
-    void(
-        NB_FLOAT[:],
-        NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
-        NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
-    ), device=True
-)
-def propagate(
-        in_neutron,
-        ww, hh, hw1, hh1, l,
-        R0, Qc, alpha, m, W,
-):
-    x, y, z, vx, vy, vz = in_neutron[:6]
-    t = in_neutron[-2]
-    prob = in_neutron[-1]
-    # propagate to z=0
-    dt = -z/vz
-    x += vx*dt; y += vy*dt; z = 0.; t += dt
-    # check opening
-    if x <= -hw1 or x >= hw1 or y <= -hh1 or y >= hh1:
-        absorb(in_neutron)
-        return
-    # bouncing loop
-    for nb in range(max_bounces):
-        av = l*vx; bv = ww*vz
-        ah = l*vy; bh = hh*vz
-        vdotn_v1 = bv + av         # Left vertical
-        vdotn_v2 = bv - av         # Right vertical
-        vdotn_h1 = bh + ah         # Lower horizontal
-        vdotn_h2 = bh - ah         # Upper horizontal
-        # Compute the dot products of (O - r) and n as c1+c2 and c1-c2 
-        cv1 = -hw1*l - z*ww; cv2 = x*l
-        ch1 = -hh1*l - z*hh; ch2 = y*l
-        # Compute intersection times.
-        t1 = (l - z) / vz  # for guide exit
-        i = 0
-        if vdotn_v1 < 0:
-            t2 = (cv1 - cv2)/vdotn_v1
-            if t2 < t1:
-                t1 = t2
-                i = 1
-        if vdotn_v2 < 0:
-            t2 = (cv1 + cv2)/vdotn_v2
-            if t2<t1:
-                t1 = t2
-                i = 2
-        if vdotn_h1 < 0:
-            t2 = (ch1 - ch2)/vdotn_h1
-            if t2<t1:
-                t1 = t2
-                i = 3
-        if vdotn_h2 < 0:
-            t2 = (ch1 + ch2)/vdotn_h2
-            if t2 < t1:
-                t1 = t2
-                i = 4
-        if i == 0:
-            break                    # Neutron left guide.
-
-        # propagate time t1 to move to reflection point
-        x += vx*t1; y += vy*t1; z += vz*t1; t += t1
-
-        # reflection
-        if i == 1:                     # Left vertical mirror
-            nlen2 = l*l + ww*ww
-            q = V2K*(-2)*vdotn_v1/sqrt(nlen2)
-            d = 2*vdotn_v1/nlen2
-            vx = vx - d*l
-            vz = vz - d*ww
-        elif i == 2:                   # Right vertical mirror
-            nlen2 = l*l + ww*ww
-            q = V2K*(-2)*vdotn_v2/sqrt(nlen2)
-            d = 2*vdotn_v2/nlen2
-            vx = vx + d*l
-            vz = vz - d*ww
-        elif i == 3:                   # Lower horizontal mirror
-            nlen2 = l*l + hh*hh
-            q = V2K*(-2)*vdotn_h1/sqrt(nlen2)
-            d = 2*vdotn_h1/nlen2
-            vy = vy - d*l
-            vz = vz - d*hh
-        elif i == 4:                   # Upper horizontal mirror
-            nlen2 = l*l + hh*hh
-            q = V2K*(-2)*vdotn_h2/sqrt(nlen2)
-            d = 2*vdotn_h2/nlen2
-            vy = vy + d*l
-            vz = vz - d*hh
-        R = calc_reflectivity(q, R0, Qc, alpha, m, W)
-        prob *= R
-        if prob <= 0:
-            break
-    in_neutron[:6] = x, y, z, vx, vy, vz
-    in_neutron[-2] = t
-    in_neutron[-1] = prob
-
 
 
 from ..ComponentBase import ComponentBase
@@ -118,7 +23,7 @@ class Guide(ComponentBase):
     def __init__(
             self, name,
             w1, h1, w2, h2, l,
-            R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.003):
+            R0=0.99, Qc=0.0219, alpha=6.07, m=2, W=0.003, **kwargs):
         """
         Initialize this Guide component.
         The guide is centered on the z-axis with the entrance at z=0.
@@ -136,6 +41,8 @@ class Guide(ComponentBase):
         m: m-value of material (0 is complete absorption)
         W: width of supermirror cutoff
         """
+        super().__init__(__class__, **kwargs)
+
         self.name = name
         ww = .5*(w2-w1); hh = .5*(h2 - h1)
         hw1 = 0.5*w1; hh1 = 0.5*h1
@@ -151,4 +58,107 @@ class Guide(ComponentBase):
         neutrons[0] = mcni.neutron(r=(0, 0, 0), v=velocity, prob=1, time=0)
         self.process(neutrons)
 
-Guide.register_propagate_method(propagate)
+    @cuda.jit(
+        void(
+            NB_FLOAT[:],
+            NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+            NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+        ), device=True
+    )
+    def propagate(
+            in_neutron,
+            ww, hh, hw1, hh1, l,
+            R0, Qc, alpha, m, W,
+    ):
+        x, y, z, vx, vy, vz = in_neutron[:6]
+        t = in_neutron[-2]
+        prob = in_neutron[-1]
+        # propagate to z=0
+        dt = -z / vz
+        x += vx * dt;
+        y += vy * dt;
+        z = 0.;
+        t += dt
+        # check opening
+        if x <= -hw1 or x >= hw1 or y <= -hh1 or y >= hh1:
+            absorb(in_neutron)
+            return
+        # bouncing loop
+        for nb in range(max_bounces):
+            av = l * vx;
+            bv = ww * vz
+            ah = l * vy;
+            bh = hh * vz
+            vdotn_v1 = bv + av  # Left vertical
+            vdotn_v2 = bv - av  # Right vertical
+            vdotn_h1 = bh + ah  # Lower horizontal
+            vdotn_h2 = bh - ah  # Upper horizontal
+            # Compute the dot products of (O - r) and n as c1+c2 and c1-c2
+            cv1 = -hw1 * l - z * ww;
+            cv2 = x * l
+            ch1 = -hh1 * l - z * hh;
+            ch2 = y * l
+            # Compute intersection times.
+            t1 = (l - z) / vz  # for guide exit
+            i = 0
+            if vdotn_v1 < 0:
+                t2 = (cv1 - cv2) / vdotn_v1
+                if t2 < t1:
+                    t1 = t2
+                    i = 1
+            if vdotn_v2 < 0:
+                t2 = (cv1 + cv2) / vdotn_v2
+                if t2 < t1:
+                    t1 = t2
+                    i = 2
+            if vdotn_h1 < 0:
+                t2 = (ch1 - ch2) / vdotn_h1
+                if t2 < t1:
+                    t1 = t2
+                    i = 3
+            if vdotn_h2 < 0:
+                t2 = (ch1 + ch2) / vdotn_h2
+                if t2 < t1:
+                    t1 = t2
+                    i = 4
+            if i == 0:
+                break  # Neutron left guide.
+
+            # propagate time t1 to move to reflection point
+            x += vx * t1;
+            y += vy * t1;
+            z += vz * t1;
+            t += t1
+
+            # reflection
+            if i == 1:  # Left vertical mirror
+                nlen2 = l * l + ww * ww
+                q = V2K * (-2) * vdotn_v1 / sqrt(nlen2)
+                d = 2 * vdotn_v1 / nlen2
+                vx = vx - d * l
+                vz = vz - d * ww
+            elif i == 2:  # Right vertical mirror
+                nlen2 = l * l + ww * ww
+                q = V2K * (-2) * vdotn_v2 / sqrt(nlen2)
+                d = 2 * vdotn_v2 / nlen2
+                vx = vx + d * l
+                vz = vz - d * ww
+            elif i == 3:  # Lower horizontal mirror
+                nlen2 = l * l + hh * hh
+                q = V2K * (-2) * vdotn_h1 / sqrt(nlen2)
+                d = 2 * vdotn_h1 / nlen2
+                vy = vy - d * l
+                vz = vz - d * hh
+            elif i == 4:  # Upper horizontal mirror
+                nlen2 = l * l + hh * hh
+                q = V2K * (-2) * vdotn_h2 / sqrt(nlen2)
+                d = 2 * vdotn_h2 / nlen2
+                vy = vy + d * l
+                vz = vz - d * hh
+            R = calc_reflectivity(q, R0, Qc, alpha, m, W)
+            prob *= R
+            if prob <= 0:
+                break
+        in_neutron[:6] = x, y, z, vx, vy, vz
+        in_neutron[-2] = t
+        in_neutron[-1] = prob

--- a/acc/components/optics/guide_tapering.py
+++ b/acc/components/optics/guide_tapering.py
@@ -39,7 +39,7 @@ class Guide(ComponentBase):
         alphay: slope of reflectivity for vertical mirrors
         W: width of supermirror cutoff
         """
-        super().__init__(**kwargs)
+        super().__init__(__class__, **kwargs)
 
         self.name = name
         self.filename = None
@@ -83,9 +83,6 @@ class Guide(ComponentBase):
             self.whalf_d, self.hhalf_d, self.lwhalf_d, self.lhhalf_d, float(R0), float(Qcx),
             float(Qcy), float(alphax), float(alphay), float(mx), float(my), float(W)
         )
-
-        self.propagate = self.register_propagate_method(self.propagate)
-        #print(self.process_kernel)
 
         self.print_kernel_info(self.propagate)
 

--- a/acc/components/optics/guide_tapering.py
+++ b/acc/components/optics/guide_tapering.py
@@ -10,192 +10,18 @@ from mcni.utils.conversion import V2K
 
 category = 'optics'
 
-from ...config import get_numba_floattype, get_numpy_floattype
 from ._guide_utils import calc_reflectivity
+from ..ComponentBase import ComponentBase
+from ...config import get_numba_floattype
 NB_FLOAT = get_numba_floattype()
-NP_FLOAT = get_numpy_floattype()
-
 
 max_bounces = 100000
-@cuda.jit(
-    void(
-        NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:],
-        NB_FLOAT,
-        NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:],
-        NB_FLOAT[:],
-        NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
-        NB_FLOAT
-    ), device=True)
-def propagate(in_neutron, w1, w2, h1, h2, l_seg, ww, hh,
-              whalf, hhalf, lwhalf, lhhalf,
-              R0, Qcx, Qcy, alphax, alphay,
-              mx, my, W):
-    x,y,z,vx,vy,vz = in_neutron[:6]
-    t = in_neutron[-2]
-    prob = in_neutron[-1]
-    # propagate to z=0
-    dt = -z/vz
-    x+=vx*dt; y+=vy*dt; z=0.0; t+=dt
-
-    # TODO: change this to a parameter possibly, impact of len() on perf?
-    nsegments = len(w1)
-
-    for seg in range(nsegments):
-        zr = seg * l_seg
-        # propagate to segment entrance
-        dt = (zr - z) / vz
-        x += vx * dt
-        y += vy * dt
-        z += vz * dt
-        if (x <= -0.5 * w1[seg] or x >= 0.5 * w1[seg] or
-            y <= -hhalf[seg] or y >= hhalf[seg]):
-            in_neutron[-1] = 0
-            return
-
-        # shift origin to center of channel hit
-        x += 0.5 * w1[seg]
-        edge = cuda.libdevice.floor(x / w1[seg]) * w1[seg]
-        if (x - edge > w1[seg]):
-            in_neutron[-1] = 0
-            return
-        x -= (edge + 0.5 * w1[seg])
-        hadj = edge + (0.5 * w1[seg]) - 0.5 * w1[seg]
-
-        # bouncing loop
-        for nb in range(max_bounces):
-            av = l_seg * vx
-            bv = ww[seg] * vz
-            ah = l_seg * vy
-            bh = hh[seg] * vz
-            vdotn_v1 = bv + av  # Left vertical
-            vdotn_v2 = bv - av  # Right vertical
-            vdotn_h1 = bh + ah  # Lower horizontal
-            vdotn_h2 = bh - ah  # Upper horizontal
-            # Compute the dot products of (O - r) and n as c1+c2 and c1-c2
-            cv1 = -whalf[seg] * l_seg - (z - zr) * ww[seg]
-            cv2 = x * l_seg
-            ch1 = -hhalf[seg] * l_seg - (z - zr) * hh[seg]
-            ch2 = y * l_seg
-            # Compute intersection times.
-            t1 = (zr + l_seg - z) / vz  # for guide exit
-            i = 0
-            if vdotn_v1 < 0:
-                t2 = (cv1 - cv2) / vdotn_v1
-                if t2 < t1:
-                    t1 = t2
-                    i = 1
-            if vdotn_v2 < 0:
-                t2 = (cv1 + cv2) / vdotn_v2
-                if t2 < t1:
-                    t1 = t2
-                    i = 2
-            if vdotn_h1 < 0:
-                t2 = (ch1 - ch2) / vdotn_h1
-                if t2 < t1:
-                    t1 = t2
-                    i = 3
-            if vdotn_h2 < 0:
-                t2 = (ch1 + ch2) / vdotn_h2
-                if t2 < t1:
-                    t1 = t2
-                    i = 4
-            if i == 0:
-                break  # Neutron left guide.
-
-            # propagate time t1 to move to reflection point
-            x += vx * t1
-            y += vy * t1
-            z += vz * t1
-            t += t1
-
-            # reflection
-            if i == 1:  # Left vertical mirror
-                nlen2 = l_seg * l_seg + ww[seg] * ww[seg]
-                q = V2K * (-2.0) * vdotn_v1 / sqrt(nlen2)
-                d = 2.0 * vdotn_v1 / nlen2
-                vx = vx - d * l_seg
-                vz = vz - d * ww[seg]
-            elif i == 2:  # Right vertical mirror
-                nlen2 = l_seg * l_seg + ww[seg] * ww[seg]
-                q = V2K * (-2.0) * vdotn_v2 / sqrt(nlen2)
-                d = 2.0 * vdotn_v2 / nlen2
-                vx = vx + d * l_seg
-                vz = vz - d * ww[seg]
-            elif i == 3:  # Lower horizontal mirror
-                nlen2 = l_seg * l_seg + hh[seg] * hh[seg]
-                q = V2K * (-2.0) * vdotn_h1 / sqrt(nlen2)
-                d = 2.0 * vdotn_h1 / nlen2
-                vy = vy - d * l_seg
-                vz = vz - d * hh[seg]
-            elif i == 4:  # Upper horizontal mirror
-                nlen2 = l_seg * l_seg + hh[seg] * hh[seg]
-                q = V2K * (-2.0) * vdotn_h2 / sqrt(nlen2)
-                d = 2.0 * vdotn_h2 / nlen2
-                vy = vy + d * l_seg
-                vz = vz - d * hh[seg]
-
-            if (i <= 2 and mx == 0) or (i > 2 and my == 0):
-                x += hadj
-                break
-
-            if i <= 2:
-                m = mx
-                if m <= 0.0:
-                    m = abs(mx * w1[0] / w1[seg])
-                R = calc_reflectivity(q, R0, Qcx, alphax, m, W)
-                if R > 1e-10:
-                    prob *= R
-                else:
-                    in_neutron[-1] = 0
-                    return
-            else:
-                m = my
-                if m <= 0.0:
-                    m = abs(my * h1[0] / h1[seg])
-                R = calc_reflectivity(q, R0, Qcy, alphay, m, W)
-                if R > 1e-10:
-                    prob *= R
-                else:
-                    in_neutron[-1] = 0
-                    return
-        x += hadj
-
-    in_neutron[:6] = x, y, z, vx, vy, vz
-    in_neutron[-2] = t
-    in_neutron[-1] = prob
-
-    return
-
-@cuda.jit()
-def prep_inputs(w1, w2, h1, h2, l_seg, ww, hh, whalf, hhalf, lwhalf, lhhalf):
-    """
-    Helper kernel to pre-compute different values for each segment on the device
-    w1, w2, h1, h2, l_seg are inputs
-    ww, hh, whalf, hhalf, lwhalf, lhhalf are outputs
-    """
-    ind = cuda.grid(1)
-    if ind > len(w1):
-        return
-    w1_ = w1[ind]
-    w2_ = w2[ind]
-    h1_ = h1[ind]
-    h2_ = h2[ind]
-
-    ww[ind] = 0.5 * (w2_ - w1_)
-    hh[ind] = 0.5 * (h2_ - h1_)
-    whalf[ind] = 0.5 * w1_
-    hhalf[ind] = 0.5 * h1_
-    lwhalf[ind] = l_seg * (0.5 * w1_)
-    lhhalf[ind] = l_seg * (0.5 * h1_)
 
 
-from ..ComponentBase import ComponentBase
 class Guide(ComponentBase):
 
-    def __init__(
-            self, name, option,
-            l, mx, my,
-            R0=0.99, Qcx=0.021, Qcy=0.021, alphax=6.07, alphay=6.07, W=0.003):
+    def __init__(self, name, option, l, mx, my, R0=0.99, Qcx=0.021, Qcy=0.021,
+                 alphax=6.07, alphay=6.07, W=0.003, **kwargs):
         """
         Initialize this Guide component.
         The guide is centered on the z-axis with the entrance at z=0.
@@ -213,6 +39,8 @@ class Guide(ComponentBase):
         alphay: slope of reflectivity for vertical mirrors
         W: width of supermirror cutoff
         """
+        super().__init__(**kwargs)
+
         self.name = name
         self.filename = None
 
@@ -235,16 +63,17 @@ class Guide(ComponentBase):
         self.w2_d = cuda.to_device(self.w2)
 
         # prepare temporary arrays on GPU
-        self.ww_d = cuda.device_array(self.nseg, dtype=NP_FLOAT)
-        self.hh_d = cuda.device_array(self.nseg, dtype=NP_FLOAT)
-        self.whalf_d = cuda.device_array(self.nseg, dtype=NP_FLOAT)
-        self.hhalf_d = cuda.device_array(self.nseg, dtype=NP_FLOAT)
-        self.lwhalf_d = cuda.device_array(self.nseg, dtype=NP_FLOAT)
-        self.lhhalf_d = cuda.device_array(self.nseg, dtype=NP_FLOAT)
+        self.ww_d = cuda.device_array(self.nseg, dtype=self.NP_FLOAT)
+        self.hh_d = cuda.device_array(self.nseg, dtype=self.NP_FLOAT)
+        self.whalf_d = cuda.device_array(self.nseg, dtype=self.NP_FLOAT)
+        self.hhalf_d = cuda.device_array(self.nseg, dtype=self.NP_FLOAT)
+        self.lwhalf_d = cuda.device_array(self.nseg, dtype=self.NP_FLOAT)
+        self.lhhalf_d = cuda.device_array(self.nseg, dtype=self.NP_FLOAT)
 
         threadsperblock = 512
         nblocks = ceil(self.nseg / threadsperblock)
         print(nblocks, threadsperblock)
+        prep_inputs = cuda.jit(self.prep_inputs_kernel)
         prep_inputs[nblocks, threadsperblock](self.w1_d, self.w2_d, self.h1_d, self.h2_d, self.l_seg, self.ww_d,
                                               self.hh_d, self.whalf_d, self.hhalf_d, self.lwhalf_d, self.lhhalf_d)
         cuda.synchronize()
@@ -254,6 +83,11 @@ class Guide(ComponentBase):
             self.whalf_d, self.hhalf_d, self.lwhalf_d, self.lhhalf_d, float(R0), float(Qcx),
             float(Qcy), float(alphax), float(alphay), float(mx), float(my), float(W)
         )
+
+        self.propagate = self.register_propagate_method(self.propagate)
+        #print(self.process_kernel)
+
+        self.print_kernel_info(self.propagate)
 
         import mcni
         neutrons = mcni.neutron_buffer(1)
@@ -284,13 +118,185 @@ class Guide(ComponentBase):
             w1.append(z)
             w2.append(w)
 
-        h1 = np.asarray(h1[:-1], dtype=NP_FLOAT)
-        h2 = np.asarray(h2[:-1], dtype=NP_FLOAT)
-        w1 = np.asarray(w1[:-1], dtype=NP_FLOAT)
-        w2 = np.asarray(w2[:-1], dtype=NP_FLOAT)
+        h1 = np.asarray(h1[:-1], dtype=self.NP_FLOAT)
+        h2 = np.asarray(h2[:-1], dtype=self.NP_FLOAT)
+        w1 = np.asarray(w1[:-1], dtype=self.NP_FLOAT)
+        w2 = np.asarray(w2[:-1], dtype=self.NP_FLOAT)
 
         file.close()
 
         return h1, h2, w1, w2
 
-Guide.register_propagate_method(propagate)
+    @classmethod
+    def prep_inputs_kernel(cls, w1, w2, h1, h2, l_seg, ww, hh, whalf, hhalf, lwhalf,
+                    lhhalf):
+        """
+        Helper kernel to pre-compute different values for each segment on the device
+        w1, w2, h1, h2, l_seg are inputs
+        ww, hh, whalf, hhalf, lwhalf, lhhalf are outputs
+        """
+        ind = cuda.grid(1)
+        if ind > len(w1):
+            return
+        w1_ = w1[ind]
+        w2_ = w2[ind]
+        h1_ = h1[ind]
+        h2_ = h2[ind]
+
+        ww[ind] = 0.5 * (w2_ - w1_)
+        hh[ind] = 0.5 * (h2_ - h1_)
+        whalf[ind] = 0.5 * w1_
+        hhalf[ind] = 0.5 * h1_
+        lwhalf[ind] = l_seg * (0.5 * w1_)
+        lhhalf[ind] = l_seg * (0.5 * h1_)
+
+    @cuda.jit(void(
+        NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:],
+        NB_FLOAT,
+        NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:],
+        NB_FLOAT[:],
+        NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+        NB_FLOAT
+    ), device=True)
+    def propagate(in_neutron, w1, w2, h1, h2, l_seg, ww, hh,
+                  whalf, hhalf, lwhalf, lhhalf,
+                  R0, Qcx, Qcy, alphax, alphay,
+                  mx, my, W):
+        x, y, z, vx, vy, vz = in_neutron[:6]
+        t = in_neutron[-2]
+        prob = in_neutron[-1]
+        # propagate to z=0
+        dt = -z / vz
+        x += vx * dt;
+        y += vy * dt;
+        z = 0.0;
+        t += dt
+
+        # TODO: change this to a parameter possibly, impact of len() on perf?
+        nsegments = len(w1)
+
+        for seg in range(nsegments):
+            zr = seg * l_seg
+            # propagate to segment entrance
+            dt = (zr - z) / vz
+            x += vx * dt
+            y += vy * dt
+            z += vz * dt
+            if (x <= -0.5 * w1[seg] or x >= 0.5 * w1[seg] or
+                    y <= -hhalf[seg] or y >= hhalf[seg]):
+                in_neutron[-1] = 0
+                return
+
+            # shift origin to center of channel hit
+            x += 0.5 * w1[seg]
+            edge = cuda.libdevice.floor(x / w1[seg]) * w1[seg]
+            if (x - edge > w1[seg]):
+                in_neutron[-1] = 0
+                return
+            x -= (edge + 0.5 * w1[seg])
+            hadj = edge + (0.5 * w1[seg]) - 0.5 * w1[seg]
+
+            # bouncing loop
+            for nb in range(max_bounces):
+                av = l_seg * vx
+                bv = ww[seg] * vz
+                ah = l_seg * vy
+                bh = hh[seg] * vz
+                vdotn_v1 = bv + av  # Left vertical
+                vdotn_v2 = bv - av  # Right vertical
+                vdotn_h1 = bh + ah  # Lower horizontal
+                vdotn_h2 = bh - ah  # Upper horizontal
+                # Compute the dot products of (O - r) and n as c1+c2 and c1-c2
+                cv1 = -whalf[seg] * l_seg - (z - zr) * ww[seg]
+                cv2 = x * l_seg
+                ch1 = -hhalf[seg] * l_seg - (z - zr) * hh[seg]
+                ch2 = y * l_seg
+                # Compute intersection times.
+                t1 = (zr + l_seg - z) / vz  # for guide exit
+                i = 0
+                if vdotn_v1 < 0:
+                    t2 = (cv1 - cv2) / vdotn_v1
+                    if t2 < t1:
+                        t1 = t2
+                        i = 1
+                if vdotn_v2 < 0:
+                    t2 = (cv1 + cv2) / vdotn_v2
+                    if t2 < t1:
+                        t1 = t2
+                        i = 2
+                if vdotn_h1 < 0:
+                    t2 = (ch1 - ch2) / vdotn_h1
+                    if t2 < t1:
+                        t1 = t2
+                        i = 3
+                if vdotn_h2 < 0:
+                    t2 = (ch1 + ch2) / vdotn_h2
+                    if t2 < t1:
+                        t1 = t2
+                        i = 4
+                if i == 0:
+                    break  # Neutron left guide.
+
+                # propagate time t1 to move to reflection point
+                x += vx * t1
+                y += vy * t1
+                z += vz * t1
+                t += t1
+
+                # reflection
+                if i == 1:  # Left vertical mirror
+                    nlen2 = l_seg * l_seg + ww[seg] * ww[seg]
+                    q = V2K * (-2.0) * vdotn_v1 / sqrt(nlen2)
+                    d = 2.0 * vdotn_v1 / nlen2
+                    vx = vx - d * l_seg
+                    vz = vz - d * ww[seg]
+                elif i == 2:  # Right vertical mirror
+                    nlen2 = l_seg * l_seg + ww[seg] * ww[seg]
+                    q = V2K * (-2.0) * vdotn_v2 / sqrt(nlen2)
+                    d = 2.0 * vdotn_v2 / nlen2
+                    vx = vx + d * l_seg
+                    vz = vz - d * ww[seg]
+                elif i == 3:  # Lower horizontal mirror
+                    nlen2 = l_seg * l_seg + hh[seg] * hh[seg]
+                    q = V2K * (-2.0) * vdotn_h1 / sqrt(nlen2)
+                    d = 2.0 * vdotn_h1 / nlen2
+                    vy = vy - d * l_seg
+                    vz = vz - d * hh[seg]
+                elif i == 4:  # Upper horizontal mirror
+                    nlen2 = l_seg * l_seg + hh[seg] * hh[seg]
+                    q = V2K * (-2.0) * vdotn_h2 / sqrt(nlen2)
+                    d = 2.0 * vdotn_h2 / nlen2
+                    vy = vy + d * l_seg
+                    vz = vz - d * hh[seg]
+
+                if (i <= 2 and mx == 0) or (i > 2 and my == 0):
+                    x += hadj
+                    break
+
+                if i <= 2:
+                    m = mx
+                    if m <= 0.0:
+                        m = abs(mx * w1[0] / w1[seg])
+                    R = calc_reflectivity(q, R0, Qcx, alphax, m, W)
+                    if R > 1e-10:
+                        prob *= R
+                    else:
+                        in_neutron[-1] = 0
+                        return
+                else:
+                    m = my
+                    if m <= 0.0:
+                        m = abs(my * h1[0] / h1[seg])
+                    R = calc_reflectivity(q, R0, Qcy, alphay, m, W)
+                    if R > 1e-10:
+                        prob *= R
+                    else:
+                        in_neutron[-1] = 0
+                        return
+            x += hadj
+
+        in_neutron[:6] = x, y, z, vx, vy, vz
+        in_neutron[-2] = t
+        in_neutron[-1] = prob
+
+        return

--- a/acc/components/optics/guide_tapering.py
+++ b/acc/components/optics/guide_tapering.py
@@ -39,8 +39,6 @@ class Guide(ComponentBase):
         alphay: slope of reflectivity for vertical mirrors
         W: width of supermirror cutoff
         """
-        super().__init__(__class__, **kwargs)
-
         self.name = name
         self.filename = None
 

--- a/acc/components/sources/SourceBase.py
+++ b/acc/components/sources/SourceBase.py
@@ -49,9 +49,10 @@ class SourceBase(base):
 
     @classmethod
     def register_propagate_method(cls, propagate):
-        cls.process_kernel = make_process_kernel(propagate)
-        cls.process_kernel_no_buffer = make_process_kernel_no_buffer(propagate)
-        return
+        new_propagate = cls._adjust_propagate_type(propagate)
+        cls.process_kernel = make_process_kernel(new_propagate)
+        cls.process_kernel_no_buffer = make_process_kernel_no_buffer(new_propagate)
+        return new_propagate
 
 
 def make_process_kernel_no_buffer(propagate):

--- a/acc/components/sources/source_simple.py
+++ b/acc/components/sources/source_simple.py
@@ -82,8 +82,6 @@ class Source_simple(SourceBase):
         gauss : bool
             Gaussian (True) or Flat (False) energy/wavelength distribution
         """
-        super().__init__(__class__, **kwargs)
-
         self.name = name
         # Determine source area:
         if (radius != 0 and height == 0 and width == 0) :

--- a/acc/components/sources/source_simple.py
+++ b/acc/components/sources/source_simple.py
@@ -2,17 +2,45 @@
 #
 
 import math
-from numba import cuda
-import numba as nb
-from numba.cuda.random import xoroshiro128p_uniform_float32, create_xoroshiro128p_states
-import time
+from numba import cuda, void, int64, boolean
+from numba.cuda.random import xoroshiro128p_uniform_float32, xoroshiro128p_type
 
 from mcni.utils.conversion import V2K, SE2V, K2V
-from .SourceBase import SourceBase, make_process_kernel
-from ...config import get_numba_floattype, get_numpy_floattype
+from .SourceBase import SourceBase
+from ...config import get_numba_floattype
+from ... import vec3
 NB_FLOAT = get_numba_floattype()
 
 category = 'sources'
+
+# TODO: need to fix float types on this function also
+@cuda.jit(device=True)
+def randvec_target_rect(
+        target, width, height, rand1, rand2,
+        vecout
+):
+    dx = width * (rand1 * 2 - 1) / 2.0
+    dy = height * (rand2 * 2 - 1) / 2.0
+    dist = vec3.length(target)
+    # horiz direction perp to target
+    p1 = cuda.local.array(shape=3, dtype=NB_FLOAT)
+    vertical = cuda.local.array(shape=3, dtype=NB_FLOAT)
+    vertical[0] = vertical[2] = 0.0
+    vertical[1] = 1.0
+    vec3.cross(target, vertical, p1)
+    vec3.normalize(p1)
+    # another perp unit vec
+    p2 = cuda.local.array(shape=3, dtype=NB_FLOAT)
+    vec3.cross(target, p1, p2)
+    vec3.normalize(p2)
+    vec3.scale(p1, dx)
+    vec3.scale(p2, dy)
+    tmp = cuda.local.array(shape=3, dtype=NB_FLOAT)
+    vec3.add(p1, target, tmp)
+    vec3.add(p2, tmp, vecout)
+    dist2 = math.sqrt(dx * dx + dy * dy + dist * dist)
+    return (width * height * dist) / (dist2 * dist2 * dist2)
+
 
 class Source_simple(SourceBase):
 
@@ -21,7 +49,7 @@ class Source_simple(SourceBase):
             radius=0.05, height=0, width=0, dist=10.0,
             xw=0.1, yh=0.1,
             E0=60, dE=10, Lambda0=0, dLambda=0,
-            flux=1, gauss=0, N=1
+            flux=1, gauss=0, N=1, **kwargs
     ):
         """
         Initialize this Source_simple component.
@@ -54,6 +82,8 @@ class Source_simple(SourceBase):
         gauss : bool
             Gaussian (True) or Flat (False) energy/wavelength distribution
         """
+        super().__init__(__class__, **kwargs)
+
         self.name = name
         # Determine source area:
         if (radius != 0 and height == 0 and width == 0) :
@@ -83,77 +113,52 @@ class Source_simple(SourceBase):
         self.process(neutrons)
 
 
-@cuda.jit(device=True)
-def propagate(
-        threadindex, rng_states,
-        in_neutron,
-        square, width, height, radius,
-        wl_distr, Lambda0, dLambda, E0, dE,
-        xw, yh, dist, pmul
-):
-    r1 = xoroshiro128p_uniform_float32(rng_states, threadindex)
-    r2 = xoroshiro128p_uniform_float32(rng_states, threadindex)
-    r3 = xoroshiro128p_uniform_float32(rng_states, threadindex)
-    r4 = xoroshiro128p_uniform_float32(rng_states, threadindex)
-    r5 = xoroshiro128p_uniform_float32(rng_states, threadindex)
-    if square:
-        x = width * (r1 - 0.5)
-        y = height * (r2 - 0.5)
-    else:
-        chi=2*math.pi*r1
-        r=math.sqrt(r2)*radius
-        x=r*math.cos(chi)
-        y=r*math.sin(chi)
-    in_neutron[:3] = x, y, 0.
-    # choose final vector
-    target = cuda.local.array(shape=3, dtype=NB_FLOAT)
-    target[0] = target[1] = 0.0
-    target[2] = dist
-    vec_f = cuda.local.array(shape=3, dtype=NB_FLOAT)
-    solidangle = randvec_target_rect(target, xw, yh, r3, r4, vec_f)
-    # vector from moderator to final position is
-    # (vec_f[0]-x, vec_f[1]-y, dist)
-    dx = vec_f[0]-x; dy = vec_f[1]-y
-    dist1 = math.sqrt(dx*dx+dy*dy+dist*dist)
-    # velocity scalar
-    if wl_distr:
-        L = Lambda0+dLambda*(r5*2-1)
-        v = K2V*(2*math.pi/L)
-    else:
-        E = E0+dE*(r5*2-1)
-        v = SE2V*math.sqrt(E)
-    in_neutron[3:6] = v*dx/dist1, v*dy/dist1, v*dist/dist1
-    in_neutron[-2] = 0
-    in_neutron[-1] = pmul*solidangle
-    return
-
-
-from ... import vec3
-@cuda.jit(device=True)
-def randvec_target_rect(
-        target, width, height, rand1, rand2,
-        vecout
-):
-    dx = width*(rand1*2-1)/2.0
-    dy = height*(rand2*2-1)/2.0
-    dist = vec3.length(target)
-    # horiz direction perp to target
-    p1 = cuda.local.array(shape=3, dtype=NB_FLOAT)
-    vertical = cuda.local.array(shape=3, dtype=NB_FLOAT)
-    vertical[0] = vertical[2] = 0.0
-    vertical[1] = 1.0
-    vec3.cross(target, vertical, p1)
-    vec3.normalize(p1)
-    # another perp unit vec
-    p2 = cuda.local.array(shape=3, dtype=NB_FLOAT)
-    vec3.cross(target, p1, p2)
-    vec3.normalize(p2)
-    vec3.scale(p1, dx)
-    vec3.scale(p2, dy)
-    tmp = cuda.local.array(shape=3, dtype=NB_FLOAT)
-    vec3.add(p1, target, tmp)
-    vec3.add(p2, tmp, vecout)
-    dist2 = math.sqrt(dx*dx + dy*dy + dist*dist)
-    return (width*height*dist)/(dist2*dist2*dist2)
-
-Source_simple.register_propagate_method(propagate)
+    @cuda.jit(void(
+        int64, xoroshiro128p_type[:],
+        NB_FLOAT[:],
+        boolean, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+        boolean, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+        NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT
+    ), device=True)
+    def propagate(
+            threadindex, rng_states,
+            in_neutron,
+            square, width, height, radius,
+            wl_distr, Lambda0, dLambda, E0, dE,
+            xw, yh, dist, pmul
+    ):
+        r1 = xoroshiro128p_uniform_float32(rng_states, threadindex)
+        r2 = xoroshiro128p_uniform_float32(rng_states, threadindex)
+        r3 = xoroshiro128p_uniform_float32(rng_states, threadindex)
+        r4 = xoroshiro128p_uniform_float32(rng_states, threadindex)
+        r5 = xoroshiro128p_uniform_float32(rng_states, threadindex)
+        if square:
+            x = width * (r1 - 0.5)
+            y = height * (r2 - 0.5)
+        else:
+            chi=2*math.pi*r1
+            r=math.sqrt(r2)*radius
+            x=r*math.cos(chi)
+            y=r*math.sin(chi)
+        in_neutron[:3] = x, y, 0.
+        # choose final vector
+        target = cuda.local.array(shape=3, dtype=NB_FLOAT)
+        target[0] = target[1] = 0.0
+        target[2] = dist
+        vec_f = cuda.local.array(shape=3, dtype=NB_FLOAT)
+        solidangle = randvec_target_rect(target, xw, yh, r3, r4, vec_f)
+        # vector from moderator to final position is
+        # (vec_f[0]-x, vec_f[1]-y, dist)
+        dx = vec_f[0]-x; dy = vec_f[1]-y
+        dist1 = math.sqrt(dx*dx+dy*dy+dist*dist)
+        # velocity scalar
+        if wl_distr:
+            L = Lambda0+dLambda*(r5*2-1)
+            v = K2V*(2*math.pi/L)
+        else:
+            E = E0+dE*(r5*2-1)
+            v = SE2V*math.sqrt(E)
+        in_neutron[3:6] = v*dx/dist1, v*dy/dist1, v*dist/dist1
+        in_neutron[-2] = 0
+        in_neutron[-1] = pmul*solidangle
+        return

--- a/acc/run_script.py
+++ b/acc/run_script.py
@@ -128,7 +128,7 @@ def process_kernel_no_buffer(
 {propagate_body}
 
 from mcvine.acc.components.sources.SourceBase import SourceBase
-class Instrument(SourceBase):
+class InstrumentBase(SourceBase):
     def __init__(self, instrument):
         offsets, rotmats = calcTransformations(instrument)
         self.propagate_params = tuple(c.propagate_params for c in instrument.components)
@@ -136,11 +136,11 @@ class Instrument(SourceBase):
         return
     def propagate(self):
         pass
-Instrument.process_kernel_no_buffer = process_kernel_no_buffer
+InstrumentBase.process_kernel_no_buffer = process_kernel_no_buffer
 
 def run(ncount, **kwds):
     instrument = loadInstrument(script, **kwds)
-    Instrument(instrument).process_no_buffer(ncount)
+    InstrumentBase(instrument).process_no_buffer(ncount)
     saveMonitorOutputs(instrument, scale_factor=1.0/ncount)
 """
 

--- a/acc/run_script.py
+++ b/acc/run_script.py
@@ -41,7 +41,7 @@ Parameters:
     modules = []
     body = []
     for i, comp in enumerate(comps):
-        modules.append(comp.__module__)
+        modules.append((comp.__module__, comp.__class__.__name__))
         prefix = (
             "thread_index, rng_states, "
             if isinstance(comp, StochasticComponentBase)
@@ -49,10 +49,12 @@ Parameters:
         )
         if i>0:
             body.append("abs2rel(neutron[:3], neutron[3:6], rotmats[{}], offsets[{}], r, v)".format(i-1, i-1))
-        body.append("compmod{}.propagate({} neutron, *args{})".format(i, prefix, i))
+        body.append("propagate{}({} neutron, *args{})".format(i, prefix, i))
         continue
-    module_imports = ['import {} as compmod{}'.format(m, i) for i, m in enumerate(modules)]
+    module_imports = ['from {} import {} as comp{}'.format(m, c, i) for i, (m, c) in enumerate(modules)]
     module_imports = '\n'.join(module_imports)
+    propagate_defs = ['propagate{} = comp{}.propagate'.format(i, i) for i in range(len(comps))]
+    propagate_defs = '\n'.join(propagate_defs)
     args = [f'args{i}' for i in range(len(comps))]
     args = ', '.join(args)
     indent = 8*' '
@@ -60,6 +62,7 @@ Parameters:
     text = compiled_script_template.format(
         script = script,
         module_imports = module_imports,
+        propagate_definitions = propagate_defs,
         args=args, propagate_body=body
     )
     if compiled_script is None:
@@ -107,6 +110,8 @@ NB_FLOAT = get_numba_floattype()
 
 {module_imports}
 
+{propagate_definitions}
+
 @cuda.jit
 def process_kernel_no_buffer(
     rng_states, N, n_neutrons_per_thread,
@@ -129,6 +134,8 @@ class Instrument(SourceBase):
         self.propagate_params = tuple(c.propagate_params for c in instrument.components)
         self.propagate_params += (offsets, rotmats)
         return
+    def propagate(self):
+        pass
 Instrument.process_kernel_no_buffer = process_kernel_no_buffer
 
 def run(ncount, **kwds):

--- a/tests/components/optics/acc_tapered_guide_instrument.py
+++ b/tests/components/optics/acc_tapered_guide_instrument.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+import os
+import mcvine
+
+from mcvine.acc.components.sources.source_simple import Source_simple
+from mcvine.acc.components.optics.guide_tapering import Guide
+from mcvine.acc.components.monitors.divpos_monitor import DivPos_monitor
+
+from mcni import rng_seed
+def seed(): return 0
+rng_seed.seed = seed
+
+thisdir = os.path.dirname(__file__)
+
+
+def instrument(guide11_dat=None, guide11_len = 10.99, guide11_mx = 6., guide11_my = 6.):
+    instrument = mcvine.instrument()
+    source = Source_simple(
+        name = 'source',
+        radius = 0., width = 0.03, height = 0.03, dist = 6.35,
+        xw = 0.35, yh = 0.35,
+        Lambda0 = 10., dLambda = 9.5,
+    )
+    instrument.append(source, position=(0,0,0.))
+
+    if guide11_dat is None:
+        guide11_dat = os.path.join(thisdir, "data", "VERDI_V01_guide1.1")
+    guide = Guide(
+        name = 'guide',
+        option="file={}".format(guide11_dat),
+        l=guide11_len, mx=guide11_mx, my=guide11_my,
+    )
+    instrument.append(guide, position=(0, 0, 6.35))
+    z_guide_end = 6.35+guide11_len
+
+    Ixdivx = DivPos_monitor(
+        name = 'Ixdivx', filename="Ixdivx.dat",
+        npos=250, xwidth=0.25, yheight=0.25,
+        ndiv=250, maxdiv=0.5,
+    #    restore_neutron=True
+    )
+    instrument.append(Ixdivx, position=(0,0,z_guide_end+1e-3))
+    '''
+    # NOTE: having more than one component of the same type appears to not work with acc run_script
+    Iydivy = DivPos_monitor(
+        name = 'Iydivy', filename="Iydivy.dat",
+        npos=250, xwidth=0.25, yheight=0.25,
+        ndiv=250, maxdiv=0.5,
+    #    restore_neutron=True
+    )
+    instrument.append(Iydivy, position=(0,0,z_guide_end+1e-3), orientation=(0, 0, 90))
+    '''
+    return instrument

--- a/tests/components/optics/check_tapered_guide_speed.py
+++ b/tests/components/optics/check_tapered_guide_speed.py
@@ -5,6 +5,8 @@
 # the input neutron data file
 
 import os, numpy as np, time
+import sys
+
 thisdir = os.path.dirname(__file__)
 
 guide11_dat = os.path.join(thisdir, "data", "VERDI_V01_guide1.1")
@@ -12,30 +14,70 @@ guide11_len = 10.99
 guide11_mx = 6.
 guide11_my = 6.
 
-def test():
-    from mcni.neutron_storage import load
-    neutron_fn = 'data/before_tapered_guide-n1e7.mcv'
-    neutrons = load(neutron_fn)
+DEFAULT_NEUTRON_FILE = 'data/before_guide.mcv'
+
+
+def test(neutron_fn=DEFAULT_NEUTRON_FILE, niter=1):
+    # load file and store copy to avoid reloading for multiple iterations
+    from mcni.neutron_storage import load, neutrons_from_npyarr, \
+        neutrons_as_npyarr, ndblsperneutron
+    neutrons_orig = load(neutron_fn)
+    neutrons_orig = neutrons_as_npyarr(neutrons_orig)
+    neutrons_orig.shape = -1, ndblsperneutron
+
     from mcvine.acc.components.optics import guide_tapering
     g = guide_tapering.Guide(
-        name = 'guide',
+        name='guide',
         option="file={}".format(guide11_dat),
         l=guide11_len, mx=guide11_mx, my=guide11_my,
     )
-    t1 = time.time()
-    g.process(neutrons)
-    print("GPU processing time:", time.time()-t1)
+    times = []
+    for i in range(niter):
+        neutrons = neutrons_from_npyarr(neutrons_orig)
+        t1 = time.time_ns()
+        g.process(neutrons)
+        delta = time.time_ns() - t1
+        times.append(delta)
+        print("GPU processing time: {} ms ({} s)".format(1e-6 * delta,
+                                                         1e-9 * delta))
 
-    neutrons = load(neutron_fn)
+    if niter > 1:
+        # report average time over niter
+        times = np.asarray(times)
+        avg = times.sum() / len(times)
+        print("--------")
+        print("Average GPU time ({} iters): {} ms ({} s)".format(niter,
+                                                                 1e-6 * avg,
+                                                                 1e-9 * avg))
+        print("--------")
+
+    neutrons = neutrons_from_npyarr(neutrons_orig)
     import mcvine.components as mc
     g = mc.optics.Guide_tapering(
-        name = 'guide',
+        name='guide',
         option="file={}".format(guide11_dat),
         l=guide11_len, mx=guide11_mx, my=guide11_my,
     )
     t1 = time.time()
     g.process(neutrons)
-    print("CPU processing time:", time.time()-t1)
+    print("CPU processing time:", time.time() - t1)
     return
 
-if __name__ == '__main__': test()
+
+if __name__ == '__main__':
+    filename = DEFAULT_NEUTRON_FILE
+    iters = 1
+
+    # usage: check_tapered_guide [-n [iter count]] [FILENAME]
+    i = 1
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+        if arg == "-n":
+            iters = int(sys.argv[i + 1])
+            i += 1
+        else:
+            filename = arg
+
+        i += 1
+
+    test(filename, iters)

--- a/tests/components/optics/tapered_guide_instrument.py
+++ b/tests/components/optics/tapered_guide_instrument.py
@@ -26,11 +26,13 @@ def instrument(
         before_guide = mc.monitors.NeutronToStorage(
             name='before_guide', path='before_tapered_guide.mcv')
         instrument.append(before_guide, position=(0, 0, 6.35))
+    kwds = {}
     if guide_mod:
         import importlib
         mod = importlib.import_module(guide_mod)
         # assume factory name is "Guide" in the given module
         guide_factory = mod.Guide
+        kwds = {'floattype': "float64"}
     elif guide_factory:
         guide_factory = eval(guide_factory)
     if guide11_dat is None:
@@ -38,7 +40,7 @@ def instrument(
     guide = guide_factory(
         name = 'guide',
         option="file={}".format(guide11_dat),
-        l=guide11_len, mx=guide11_mx, my=guide11_my,
+        l=guide11_len, mx=guide11_mx, my=guide11_my, **kwds
     )
     instrument.append(guide, position=(0, 0, 6.35))
     z_guide_end = 6.35+guide11_len

--- a/tests/components/test_ComponentBase.py
+++ b/tests/components/test_ComponentBase.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+import pytest
+
+import numba
+from numba import cuda, void, float32
+from numba.core.types import Array, Float
+from mcvine.acc.components.ComponentBase import ComponentBase
+from mcvine.acc import test
+
+
+def test_no_propagate_raises():
+    with pytest.raises(TypeError):
+        # check creating a component with no propagate method raises error
+        class Component(ComponentBase):
+            def __init__(self, **kwargs):
+                super().__init__(__class__, **kwargs)
+        component = Component()
+
+
+@pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
+def test_propagate_no_signature_raises():
+    with pytest.raises(RuntimeError):
+        # check that defining a propagate function with no signature fails
+        class Component(ComponentBase):
+            def __init__(self, **kwargs):
+                super().__init__(__class__, **kwargs)
+
+            @cuda.jit(device=True)
+            def propagate():
+                pass
+        component = Component()
+
+
+@pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
+def test_set_float():
+    class Component(ComponentBase):
+        def __init__(self, **kwargs):
+            super().__init__(__class__, **kwargs)
+
+        @cuda.jit(void(), device=True)
+        def propagate():
+            pass
+
+    component = Component(floattype="float32")
+
+    # Both the instance and class attribute should have changed
+    assert component.floattype == "float32"
+    assert Component.get_floattype() == "float32"
+
+
+@pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
+def test_propagate_args_changed():
+    # check that propagate arguments are changed from float64 -> float32
+    NB_FLOAT = getattr(numba, "float64")
+    class Component(ComponentBase):
+        def __init__(self, **kwargs):
+            super().__init__(__class__, **kwargs)
+
+        @cuda.jit(void(NB_FLOAT, NB_FLOAT[:]), device=True)
+        def propagate(x, y):
+            y[0] = x + 1.0
+
+    component = Component(floattype="float32")
+    assert component.floattype == "float32"
+
+    # check that the class wide attributes are changed
+    assert Component.get_floattype() == "float32"
+    assert Component.process_kernel is not None
+    args = Component.propagate.args
+    assert len(args) == 2
+
+    assert isinstance(args[0], Float)
+    assert args[0].bitwidth == 32
+    assert isinstance(args[1], Array)
+    assert args[1].dtype == float32
+

--- a/tests/components/test_ComponentBase.py
+++ b/tests/components/test_ComponentBase.py
@@ -14,7 +14,8 @@ def test_no_propagate_raises():
         # check creating a component with no propagate method raises error
         class Component(ComponentBase):
             def __init__(self, **kwargs):
-                super().__init__(__class__, **kwargs)
+                # super().__init__(__class__, **kwargs)
+                return
         component = Component()
 
 
@@ -36,13 +37,15 @@ def test_propagate_no_signature_raises():
 def test_set_float():
     class Component(ComponentBase):
         def __init__(self, **kwargs):
-            super().__init__(__class__, **kwargs)
+            # super().__init__(__class__, **kwargs)
+            return
 
         @cuda.jit(void(), device=True)
         def propagate():
             pass
 
-    component = Component(floattype="float32")
+    component = Component()
+    Component.change_floattype("float32")
 
     # Both the instance and class attribute should have changed
     assert component.floattype == "float32"
@@ -55,13 +58,15 @@ def test_propagate_args_changed():
     NB_FLOAT = getattr(numba, "float64")
     class Component(ComponentBase):
         def __init__(self, **kwargs):
-            super().__init__(__class__, **kwargs)
+            #super().__init__(__class__, **kwargs)
+            return
 
         @cuda.jit(void(NB_FLOAT, NB_FLOAT[:]), device=True)
         def propagate(x, y):
             y[0] = x + 1.0
 
-    component = Component(floattype="float32")
+    component = Component()
+    Component.change_floattype("float32")
     assert component.floattype == "float32"
 
     # check that the class wide attributes are changed

--- a/tests/components/test_src_guide.py
+++ b/tests/components/test_src_guide.py
@@ -52,6 +52,11 @@ def call_process_no_buffer(
     )
     cuda.synchronize()
 
+
+source_propagate = source_simple.Source_simple.propagate
+guide_propagate = guide.Guide.propagate
+
+
 @cuda.jit
 def process_kernel_no_buffer(
         N,
@@ -65,7 +70,7 @@ def process_kernel_no_buffer(
     x = cuda.grid(1)
     if x < N:
         neutron = cuda.local.array(shape=10, dtype=FLOAT)
-        source_simple.propagate(
+        source_propagate(
             x, rng_states,
             neutron,
             square, width, height, radius,
@@ -73,7 +78,7 @@ def process_kernel_no_buffer(
             xw, yh, dist, pmul
         )
         neutron[2] -= dist
-        guide.propagate(
+        guide_propagate(
             neutron,
             ww, hh, hw1, hh1, l,
             R0, Qc, alpha, m, W,

--- a/tests/components/test_src_guide.py
+++ b/tests/components/test_src_guide.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+"""
+This one is slower than test_src_guide_mon because too many threads: nthreads=ncount
+"""
 
 import os, pytest, time
 thisdir = os.path.dirname(__file__)

--- a/tests/tapered_speed_check.json
+++ b/tests/tapered_speed_check.json
@@ -4,10 +4,33 @@
   "output_file": "./check_speed_output.txt",
   "scripts": [
     {
+      "name": "nonacc",
+      "file": "components/optics/tapered_guide_instrument.py",
+      "kwds": {
+        "guide_factory": "mcvine.components.optics.Guide_tapering"
+      },
+      "mpi": false,
+      "acc_run": false,
+      "skip_for": "1e8"
+    },
+    {
+      "name": "acc",
       "file": "components/optics/tapered_guide_instrument.py",
       "kwds": {
         "guide_mod": "mcvine.acc.components.optics.guide_tapering"
-      }
+      },
+      "mpi": false,
+      "acc_run": false
+    },
+    {
+      "name": "MPI-8Cores",
+      "file": "components/optics/tapered_guide_instrument.py",
+      "kwds": {
+        "guide_factory": "mcvine.components.optics.Guide_tapering"
+      },
+      "mpi": true,
+      "nodes": 8,
+      "acc_run": false
     }
   ]
 }


### PR DESCRIPTION
This updates the `ComponentBase` class to allow float type switching, as well as enforcing the existence of a `propagate` method in subclasses.

Major changes include:

- The `propagate` method is now defined from within component classes as opposed to outside them. Subclasses must define this method, or else an error will be raised.
- Components no longer need to explicitly register a propagate method ~~, and instead just have to call `super().__init__(__class__, **kwargs)` from within the Component subclass `__init__` method.~~
  * 03232022: requirement of calling `super().__init__` was removed. It is now done by the metaclass
- ~~Components can now accept a `floattype` argument passed in as `**kwargs`. This can be either "float64" (default), or "float32".~~
  * 03232022: components can change floattype by `ComponentClass.change_floattype(newtype)`
- The `propagate` method must define a signature in its `@cuda.jit` decorator. If not, this will raise an error. This signature can use the default float type ("float64") without needing to specify "float32" - this will be automatically converted on-the-fly when needed.

All currently existing components have been updated for these new changes: `Arm`, `Beamstop`, `DivPos_Monitor`, `Guide`, `Guide_tapering`, `Slit`, `Source_simple`, and `Wavelength_Monitor`
