### PR TITLE
Refactor tests for some components to share common code

### DIFF
--- a/tests/components/optics/arm_instrument.py
+++ b/tests/components/optics/arm_instrument.py
@@ -11,7 +11,5 @@ def instrument(is_acc):
         import mcvine.components
         factory = mcvine.components.optics.Arm
 
-    target = factory(
-        name='arm'
-    )
+    target = factory(name='arm')
     return construct(target, 0.)

--- a/tests/components/optics/arm_instrument.py
+++ b/tests/components/optics/arm_instrument.py
@@ -1,38 +1,17 @@
 #!/usr/bin/env python
 
-import mcvine, mcvine.components
-mc = mcvine.components
-
-from mcni import rng_seed
-rng_seed.seed = lambda: 0
+from instrument_factory import construct
 
 
-def instrument(
-        arm_mod=None, arm_factory=None,
-):
-    instrument = mcvine.instrument()
-    source = mc.sources.Source_simple(
-        name='source',
-        radius=0., width=0.03, height=0.03, dist=12.,
-        xw=0.035, yh=0.035,
-        Lambda0=10., dLambda=9.5,
-    )
-    instrument.append(source, position=(0, 0, 0.))
-    if arm_mod:
-        import importlib
-        mod = importlib.import_module(arm_mod)
-        # assume factory name is "Arm" in the given module
-        arm_factory = mod.Arm
-    elif arm_factory:
-        arm_factory = eval(arm_factory)
-    acc_arm = arm_factory(
+def instrument(is_acc):
+    if is_acc:
+        from mcvine.acc.components.optics.arm import Arm
+        factory = Arm
+    else:
+        import mcvine.components
+        factory = mcvine.components.optics.Arm
+
+    target = factory(
         name='arm'
     )
-    instrument.append(acc_arm, position=(0, 0, 1.))
-    Ixy = mc.monitors.PSD_monitor(
-        name='Ixy', nx=250, ny=250, filename="Ixy.dat", xwidth=0.05,
-        yheight=0.05,
-        restore_neutron=True
-    )
-    instrument.append(Ixy, position=(0, 0, 12))
-    return instrument
+    return construct(target, 0.)

--- a/tests/components/optics/beamstop_instrument.py
+++ b/tests/components/optics/beamstop_instrument.py
@@ -1,51 +1,18 @@
 #!/usr/bin/env python
 
-import mcvine, mcvine.components
-mc = mcvine.components
-from mcni import rng_seed
-
-rng_seed.seed = lambda: 0
+from instrument_factory import construct
 
 
-def instrument(
-        module=None, factory=None,
-):
-    instrument = mcvine.instrument()
-    source = mc.sources.Source_simple(
-        name='source',
-        radius=0., width=0.03, height=0.03, dist=1.,
-        xw=0.04, yh=0.04,
-        Lambda0=10., dLambda=9.5
-    )
-    instrument.append(source, position=(0, 0, 0))
-    if module:
-        import importlib
-        module = importlib.import_module(module)
-        # assume factory name is "Beamstop" in the given module
-        factory = module.Beamstop
-    elif factory:
-        factory = eval(factory)
-    acc_beamstop = factory(
+def instrument(is_acc):
+    if is_acc:
+        from mcvine.acc.components.optics.beamstop import Beamstop
+        factory = Beamstop
+    else:
+        import mcvine.components
+        factory = mcvine.components.optics.Beamstop
+
+    target = factory(
         name='beamstop',
         radius=0.015
     )
-    instrument.append(acc_beamstop, position=(0, 0, 1))
-    Ixy = mc.monitors.PSD_monitor(
-        name='Ixy',
-        nx=250, ny=250, filename="Ixy.dat", xwidth=0.10, yheight=0.10,
-        restore_neutron=True
-    )
-    instrument.append(Ixy, position=(0, 0, 1.5))
-    Ixdivx = mc.monitors.DivPos_monitor(
-        name='Ixdivx',
-        npos=250, ndiv=250, filename="Ixdivx.dat", xwidth=0.10, yheight=0.10,
-        restore_neutron=True
-    )
-    instrument.append(Ixdivx, position=(0, 0, 1.5))
-    Iydivy = mc.monitors.DivPos_monitor(
-        name='Iydivy',
-        npos=250, ndiv=250, filename="Iydivy.dat", xwidth=0.10, yheight=0.10,
-        restore_neutron=True
-    )
-    instrument.append(Iydivy, position=(0, 0, 1.5), orientation=(0, 0, 90))
-    return instrument
+    return construct(target, 0.)

--- a/tests/components/optics/beamstop_instrument.py
+++ b/tests/components/optics/beamstop_instrument.py
@@ -11,8 +11,5 @@ def instrument(is_acc):
         import mcvine.components
         factory = mcvine.components.optics.Beamstop
 
-    target = factory(
-        name='beamstop',
-        radius=0.015
-    )
+    target = factory(name='beamstop', radius=0.015)
     return construct(target, 0.)

--- a/tests/components/optics/guide_instrument.py
+++ b/tests/components/optics/guide_instrument.py
@@ -1,57 +1,28 @@
 #!/usr/bin/env python
 
-import mcvine, mcvine.components
-mc = mcvine.components
-from mcni import rng_seed
-def seed(): return 0
-rng_seed.seed = seed
+from instrument_factory import construct
+
 
 def instrument(
-        guide_mod=None, guide_factory=None,
-        save_neutrons_before_guide=False, save_neutrons_after_guide=False,
-):
-    instrument = mcvine.instrument()
-    source = mc.sources.Source_simple(
-        name = 'source',
-        radius = 0., width = 0.03, height = 0.03, dist = 1.,
-        xw = 0.035, yh = 0.035,
-        Lambda0 = 10., dLambda = 9.5,
-    )
-    instrument.append(source, position=(0,0,0.))
-    if save_neutrons_before_guide:
-        before_guide = mc.monitors.NeutronToStorage(name='before_guide', path='before_guide.mcv')
-        instrument.append(before_guide, position=(0, 0, 1.))
-    if guide_mod:
+        guide_mod=None, guide_factory=None, is_acc=False):
+    if guide_factory:
+        import mcvine.components
+        factory = eval(guide_factory)
+    elif guide_mod:
         import importlib
-        mod = importlib.import_module(guide_mod)
-        # assume factory name is "Guide" in the given module
-        guide_factory = mod.Guide
-    elif guide_factory:
-        guide_factory = eval(guide_factory)
-    acc_guide = guide_factory(
-        name = 'guide',
-        w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=10,
-        R0=0.99, Qc=0.0219, alpha=6.07, m=3, W=0.003,
+        guide_module = importlib.import_module(guide_mod)
+        factory = guide_module.Guide
+    elif is_acc:
+        from mcvine.acc.components.optics.guide import Guide
+        factory = Guide
+    else:
+        import mcvine.components
+        factory = mcvine.components.optics.Guide
+
+    guide_length = 10.
+    target = factory(
+        name='guide',
+        w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=guide_length,
+        R0=0.99, Qc=0.0219, alpha=6.07, m=3, W=0.003
     )
-    instrument.append(acc_guide, position=(0, 0, 1.))
-    if save_neutrons_after_guide:
-        after_guide = mc.monitors.NeutronToStorage(name='after_guide', path='after_guide.mcv')
-        instrument.append(after_guide, position=(0, 0, 11.))
-    Ixy = mc.monitors.PSD_monitor(
-        name = 'Ixy', nx=250, ny=250, filename="Ixy.dat", xwidth=0.08, yheight=0.08,
-        restore_neutron=True
-    )
-    instrument.append(Ixy, position=(0,0,12))
-    Ixdivx = mc.monitors.DivPos_monitor(
-        name = 'Ixdivx',
-        npos=250, ndiv=250, filename="Ixdivx.dat", xwidth=0.08, yheight=0.08,
-        restore_neutron=True
-    )
-    instrument.append(Ixdivx, position=(0,0,12))
-    Iydivy = mc.monitors.DivPos_monitor(
-        name = 'Iydivy',
-        npos=250, ndiv=250, filename="Iydivy.dat", xwidth=0.08, yheight=0.08,
-        restore_neutron=True
-    )
-    instrument.append(Iydivy, position=(0,0,12), orientation=(0, 0, 90))
-    return instrument
+    return construct(target, guide_length)

--- a/tests/components/optics/guide_instrument.py
+++ b/tests/components/optics/guide_instrument.py
@@ -3,8 +3,7 @@
 from instrument_factory import construct
 
 
-def instrument(
-        guide_mod=None, guide_factory=None, is_acc=False):
+def instrument(guide_mod=None, guide_factory=None, is_acc=False):
     if guide_factory:
         import mcvine.components
         factory = eval(guide_factory)

--- a/tests/components/optics/instrument_factory.py
+++ b/tests/components/optics/instrument_factory.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2021-2022 by UT-Battelle, LLC.
+
+import mcvine.components
+mc = mcvine.components
+
+from mcni import rng_seed
+rng_seed.seed = lambda: 0
+
+class InstrumentBuilder:
+    """
+    Helper for constructing an instrument as a sequence of components positioned
+    along increasing z. Methods can have more arguments and complexity added
+    as need for flexibility arises.
+    """
+
+    def __init__(self):
+        self.instrument = mcvine.instrument()
+        self.z = 0.
+
+    @classmethod
+    def get_source(cls):
+        """
+        Construct a source.
+        """
+        return mc.sources.Source_simple(
+            name='source',
+            radius=0., width=0.03, height=0.03, dist=1.,
+            xw=0.035, yh=0.035,
+            Lambda0=10., dLambda=9.5
+        )
+
+    @classmethod
+    def get_monitor(cls, subtype, name, **kwargs):
+        """
+        Construct a monitor.
+        Extra keyword arguments are passed to the given subtype.
+
+        Parameters:
+        subtype (str): which kind of monitor, e.g., "PSD_monitor"
+        name (str): the name of the monitor and its files, e.g., "Ixy"
+        """
+        return getattr(mc.monitors, subtype)(
+            name=name, filename=name+".dat",
+            xwidth=0.1, yheight=0.1,
+            restore_neutron=True,
+            **kwargs
+        )
+
+    def add(self, component, gap=0., is_rotated=False):
+        """
+        Add a component to the instrument.
+
+        Parameters:
+        component: the component to add
+        gap (float): how much space along z to leave between this and the next
+        is_rotated (bool): if to rotate this instrument in positioning it
+        """
+        self.instrument.append(component, position=(0., 0., self.z),
+                               orientation=(0., 0., 90. if is_rotated else 0.))
+        self.z += gap
+
+
+def construct(component, size, gap=1.,
+              monitors=["Ixy", "Ixdivx", "Ixdivy"],
+              save_neutrons_before=False, save_neutrons_after=False):
+    """
+    Construct an instrument.
+
+    Parameters:
+    component: the optics of interest, to place between sources and monitors
+    size (float): the size of the component along the z-axis
+    gap (float): how much space between the source, optics, and monitors
+    monitors (list): the names of the monitors to include, e.g., "Ixy"
+    save_neutrons_before (bool): if to save neutrons before the given optics
+    save_neutrons_after (bool): if to save neutrons after the given optics
+    """
+    builder = InstrumentBuilder()
+
+    # source
+    builder.add(builder.get_source(), gap=gap)
+
+    # instrument
+    if save_neutrons_before:
+        before = mc.monitors.NeutronToStorage(
+            name=f"before_{component.name}",
+            path=f"before_{component.name}.mcv")
+        builder.add(before)
+    if save_neutrons_after:
+        builder.add(component, gap=size)
+        after = mc.monitors.NeutronToStorage(
+            name=f"after_{component.name}",
+            path=f"after_{component.name}.mcv")
+        builder.add(after, gap=gap)
+    else:
+        builder.add(component, gap=size+gap)
+
+    # monitors
+    if "Ixy" in monitors:
+        builder.add(builder.get_monitor("PSD_monitor", "Ixy",
+                                  nx=250, ny=250))
+    if "Ixdivx" in monitors:
+        builder.add(builder.get_monitor("DivPos_monitor", "Ixdivx",
+                                  npos=250, ndiv=250))
+    if "Ixdivy" in monitors:
+        builder.add(builder.get_monitor("DivPos_monitor", "Ixdivy",
+                                  npos=250, ndiv=250), is_rotated=True)
+
+    return builder.instrument

--- a/tests/components/optics/slit_instrument.py
+++ b/tests/components/optics/slit_instrument.py
@@ -1,51 +1,18 @@
 #!/usr/bin/env python
 
-import mcvine, mcvine.components
-mc = mcvine.components
-from mcni import rng_seed
-
-rng_seed.seed = lambda: 0
+from instrument_factory import construct
 
 
-def instrument(
-        module=None, factory=None,
-):
-    instrument = mcvine.instrument()
-    source = mc.sources.Source_simple(
-        name='source',
-        radius=0., width=0.03, height=0.03, dist=1.,
-        xw=0.035, yh=0.035,
-        Lambda0=10., dLambda=9.5
-    )
-    instrument.append(source, position=(0, 0, 0))
-    if module:
-        import importlib
-        mod = importlib.import_module(module)
-        # assume factory name is "Slit" in the given module
-        factory = mod.Slit
-    elif factory:
-        factory = eval(factory)
-    acc_slit = factory(
+def instrument(is_acc):
+    if is_acc:
+        from mcvine.acc.components.optics.slit import Slit
+        factory = Slit
+    else:
+        import mcvine.components
+        factory = mcvine.components.optics.Slit
+
+    target = factory(
         name='slit',
         width=0.02, height=0.01, cut=0.001
     )
-    instrument.append(acc_slit, position=(0, 0, 1))
-    Ixy = mc.monitors.PSD_monitor(
-        name='Ixy',
-        nx=250, ny=250, filename="Ixy.dat", xwidth=0.08, yheight=0.08,
-        restore_neutron=True
-    )
-    instrument.append(Ixy, position=(0, 0, 1.5))
-    Ixdivx = mc.monitors.DivPos_monitor(
-        name='Ixdivx',
-        npos=250, ndiv=250, filename="Ixdivx.dat", xwidth=0.08, yheight=0.08,
-        restore_neutron=True
-    )
-    instrument.append(Ixdivx, position=(0, 0, 1.5))
-    Iydivy = mc.monitors.DivPos_monitor(
-        name='Iydivy',
-        npos=250, ndiv=250, filename="Iydivy.dat", xwidth=0.08, yheight=0.08,
-        restore_neutron=True
-    )
-    instrument.append(Iydivy, position=(0, 0, 1.5), orientation=(0, 0, 90))
-    return instrument
+    return construct(target, 0.)

--- a/tests/components/optics/test_arm.py
+++ b/tests/components/optics/test_arm.py
@@ -6,25 +6,23 @@ import pytest
 from mcvine.acc import test
 
 thisdir = os.path.dirname(__file__)
-interactive = False
 
 
 @pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
-def test_compare_mcvine(num_neutrons=int(1e7), debug=False):
+def test_compare_mcvine(num_neutrons=int(1e7), debug=False, interactive=False):
     """
     Tests the acc cpu implementation of an arm against mcvine
     """
     import test_helper
-    test_helper.compare_mcvine("Arm",
-                               ["Ixy", "Ixdivx", "Ixdivy"],
-                               {"float32": 1e-10, "float64": 1e-25},
-                               num_neutrons, debug)
+    test_helper.compare_mcvine(
+        "Arm",
+        ["Ixy", "Ixdivx", "Ixdivy"],
+        {"float32": 1e-10, "float64": 1e-25},
+        num_neutrons, debug, interactive=interactive)
 
 
 def main():
-    global interactive
-    interactive = True
-    test_compare_mcvine(num_neutrons=int(1e6))
+    test_compare_mcvine(num_neutrons=int(1e6), interactive=True)
     return
 
 

--- a/tests/components/optics/test_arm.py
+++ b/tests/components/optics/test_arm.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python
 
 import os
-import histogram.hdf as hh
-import numpy as np
 import pytest
-import shutil
 
-from mcvine.acc import config
-# config.floattype = "float32"
-
-from mcvine import run_script
 from mcvine.acc import test
-from mcvine.acc.config import get_numpy_floattype
 
 thisdir = os.path.dirname(__file__)
 interactive = False
@@ -22,45 +14,11 @@ def test_compare_mcvine(num_neutrons=int(1e7), debug=False):
     """
     Tests the acc cpu implementation of an arm against mcvine
     """
-    if debug:
-        assert num_neutrons < 1001
-    # Run the mcvine instrument first
-    instr = os.path.join(thisdir, "arm_instrument.py")
-    mcvine_outdir = 'out.debug-mcvine_arm_cpu_instrument'
-    if os.path.exists(mcvine_outdir):
-        shutil.rmtree(mcvine_outdir)
-    run_script.run1(
-        instr, mcvine_outdir,
-        ncount=num_neutrons, buffer_size=num_neutrons,
-        arm_factory="mcvine.components.optics.Arm",
-        overwrite_datafiles=True)
-
-    # Run our arm implementation
-    outdir = 'out.debug-arm_gpu_instrument'
-    if os.path.exists(outdir):
-        shutil.rmtree(outdir)
-    run_script.run1(
-        instr, outdir,
-        ncount=num_neutrons, buffer_size=num_neutrons,
-        arm_mod="mcvine.acc.components.optics.arm",
-        overwrite_datafiles=True, )
-
-    # Compare output files
-    mcvine_Ixy = hh.load(os.path.join(mcvine_outdir, "Ixy.h5"))
-    Ixy = hh.load(os.path.join(outdir, "Ixy.h5"))
-
-    global interactive
-    if interactive:
-        from histogram import plot as plotHist
-        plotHist(mcvine_Ixy)
-        plotHist(Ixy)
-        plotHist((Ixy-mcvine_Ixy)/mcvine_Ixy)
-    assert mcvine_Ixy.shape() == Ixy.shape()
-
-    tolerance = 1e-10 if get_numpy_floattype() == np.float32 else 1e-25
-    assert np.allclose(
-        mcvine_Ixy.data().storage(), Ixy.data().storage(),
-        atol=tolerance)
+    import test_helper
+    test_helper.compare_mcvine("Arm",
+                               ["Ixy", "Ixdivx", "Ixdivy"],
+                               {"float32": 1e-10, "float64": 1e-25},
+                               num_neutrons, debug)
 
 
 def main():

--- a/tests/components/optics/test_guide.py
+++ b/tests/components/optics/test_guide.py
@@ -5,32 +5,28 @@ import pytest
 from mcvine.acc import test
 
 thisdir = os.path.dirname(__file__)
-interactive = False
 
 
 @pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
-def test_compare_mcvine(num_neutrons=int(1e7), debug=False):
+def test_compare_mcvine(num_neutrons=int(1e7), debug=False, interactive=False):
     """
     Tests the acc cpu implementation of a straight guide against mcvine
     """
     import test_helper
-    test_helper.compare_mcvine("Guide",
-                               ["Ixy", "Ixdivx", "Ixdivy"],
-                               {"float32": 1e-7, "float64": 1e-8},
-                               num_neutrons, debug)
+    test_helper.compare_mcvine(
+        "Guide",
+        ["Ixy", "Ixdivx", "Ixdivy"],
+        {"float32": 1e-7, "float64": 1e-8},
+        num_neutrons, debug, interactive=interactive)
 
 
 def debug():
-    global interactive
-    interactive = True
-    test_compare_mcvine(debug=True, num_neutrons=100)
+    test_compare_mcvine(debug=True, num_neutrons=100, interactive=True)
     return
 
 
 def main():
-    global interactive
-    interactive = True
-    test_compare_mcvine(num_neutrons=int(1e6))
+    test_compare_mcvine(num_neutrons=int(1e6), interactive=True)
     return
 
 

--- a/tests/components/optics/test_guide.py
+++ b/tests/components/optics/test_guide.py
@@ -1,15 +1,8 @@
 #!/usr/bin/env python
 
 import os
-import histogram.hdf as hh
-import numpy as np
 import pytest
-import shutil
-from mcni import neutron_buffer, neutron
-from mcni.neutron_storage import neutrons_as_npyarr, ndblsperneutron
-from mcvine import run_script
 from mcvine.acc import test
-from mcvine.acc.config import get_numpy_floattype
 
 thisdir = os.path.dirname(__file__)
 interactive = False
@@ -20,53 +13,11 @@ def test_compare_mcvine(num_neutrons=int(1e7), debug=False):
     """
     Tests the acc cpu implementation of a straight guide against mcvine
     """
-    if debug:
-        assert num_neutrons < 1001
-    # Run the mcvine instrument first
-    instr = os.path.join(thisdir, "guide_instrument.py")
-    mcvine_outdir = 'out.debug-mcvine_guide_cpu_instrument'
-    if os.path.exists(mcvine_outdir):
-        shutil.rmtree(mcvine_outdir)
-    run_script.run1(
-        instr, mcvine_outdir,
-        ncount=num_neutrons, buffer_size=num_neutrons,
-        guide_factory="mcvine.components.optics.Guide",
-        save_neutrons_after_guide=debug,
-        overwrite_datafiles=True)
-
-    # Run our guide implementation
-    outdir = 'out.debug-guide_gpu_instrument'
-    if os.path.exists(outdir):
-        shutil.rmtree(outdir)
-    run_script.run1(
-        instr, outdir,
-        ncount=num_neutrons, buffer_size=num_neutrons,
-        guide_mod="mcvine.acc.components.optics.guide",
-        save_neutrons_after_guide=debug,
-        overwrite_datafiles=True, )
-
-    # Compare output files
-    mcvine_Ixy = hh.load(os.path.join(mcvine_outdir, "Ixy.h5"))
-    mcvine_Ixdivx = hh.load(os.path.join(mcvine_outdir, "Ixdivx.h5"))
-    Ixy = hh.load(os.path.join(outdir, "Ixy.h5"))
-    Ixdivx = hh.load(os.path.join(outdir, "Ixdivx.h5"))
-
-    global interactive
-    if interactive:
-        from histogram import plot as plotHist
-        plotHist(mcvine_Ixy)
-        plotHist(mcvine_Ixdivx)
-        plotHist(Ixy)
-        plotHist(Ixdivx)
-        plotHist((Ixy-mcvine_Ixy)/mcvine_Ixy)
-    assert mcvine_Ixy.shape() == Ixy.shape()
-    assert mcvine_Ixdivx.shape() == Ixdivx.shape()
-
-    tolerance = 1e-7 if get_numpy_floattype() == np.float32 else 1e-8
-    assert np.allclose(mcvine_Ixy.data().storage(), Ixy.data().storage(),
-                       atol=tolerance)
-    assert np.allclose(mcvine_Ixdivx.data().storage(), Ixdivx.data().storage(),
-                       atol=tolerance)
+    import test_helper
+    test_helper.compare_mcvine("Guide",
+                               ["Ixy", "Ixdivx", "Ixdivy"],
+                               {"float32": 1e-7, "float64": 1e-8},
+                               num_neutrons, debug)
 
 
 def debug():

--- a/tests/components/optics/test_helper.py
+++ b/tests/components/optics/test_helper.py
@@ -12,10 +12,9 @@ from mcvine.acc import test
 from mcvine.acc.config import floattype
 
 thisdir = os.path.dirname(__file__)
-interactive = False
 
 
-def compare_mcvine(className, monitors, tolerances, num_neutrons, debug):
+def compare_mcvine(className, monitors, tolerances, num_neutrons, debug, interactive=False):
     """
     Tests the acc cpu implementation of an instrument against mcvine.
 
@@ -57,7 +56,6 @@ def compare_mcvine(className, monitors, tolerances, num_neutrons, debug):
 
     # Compare output files
     tolerance = tolerances[floattype]
-    global interactive
     for monitor in monitors:
         mcvine = hh.load(os.path.join(mcvine_outdir, monitor + ".h5"))
         mcvine_acc = hh.load(os.path.join(outdir, monitor + ".h5"))

--- a/tests/components/optics/test_helper.py
+++ b/tests/components/optics/test_helper.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+from mcvine.acc import config
+# config.floattype = "float32"
+
+import os
+import histogram.hdf as hh
+import numpy as np
+import shutil
+from mcvine import run_script
+from mcvine.acc import test
+from mcvine.acc.config import floattype
+
+thisdir = os.path.dirname(__file__)
+interactive = False
+
+
+def compare_mcvine(className, monitors, tolerances, num_neutrons, debug):
+    """
+    Tests the acc cpu implementation of an instrument against mcvine.
+
+    Parameters:
+    className (str): the name of the instrument class under test, e.g., "Guide"
+    monitors (list): the names of the monitors to use in testing, e.g., "Ixy"
+    tolerances (dict): tolerance of float comparisons, e.g., "float32": 1e-8
+    num_neutrons (int): how many neutrons to use in the testing
+    debug (bool): if to save the neutrons that exit the instrument
+    """
+    if debug:
+        assert num_neutrons < 1001
+    classname = className.lower()
+
+    # Run the mcvine instrument first
+    instr = os.path.join(thisdir, f"{classname}_instrument.py")
+    mcvine_outdir = f"out.debug-mcvine_{classname}_cpu_instrument"
+    if os.path.exists(mcvine_outdir):
+        shutil.rmtree(mcvine_outdir)
+    run_script.run1(
+        instr, mcvine_outdir,
+        ncount=num_neutrons, buffer_size=num_neutrons,
+        factory=f"mcvine.components.optics.{className}",
+        save_neutrons_after=debug,
+        overwrite_datafiles=True,
+        is_acc=False)
+
+    # Run our accelerated implementation
+    outdir = f"out.debug-{classname}_gpu_instrument"
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+    run_script.run1(
+        instr, outdir,
+        ncount=num_neutrons, buffer_size=num_neutrons,
+        module=f"mcvine.acc.components.optics.{classname}",
+        save_neutrons_after=debug,
+        overwrite_datafiles=True,
+        is_acc=True)
+
+    # Compare output files
+    tolerance = tolerances[floattype]
+    global interactive
+    for monitor in monitors:
+        mcvine = hh.load(os.path.join(mcvine_outdir, monitor + ".h5"))
+        mcvine_acc = hh.load(os.path.join(outdir, monitor + ".h5"))
+        if interactive:
+            from histogram import plot as plotHist
+            plotHist(mcvine)
+            plotHist(mcvine_acc)
+            plotHist((mcvine_acc - mcvine) / mcvine)
+        assert mcvine.shape() == mcvine_acc.shape()
+        assert np.allclose(mcvine.data().storage(), mcvine_acc.data().storage(),
+                           atol=tolerance)

--- a/tests/components/optics/test_slit_beamstop.py
+++ b/tests/components/optics/test_slit_beamstop.py
@@ -1,16 +1,10 @@
 #!/usr/bin/env python
 
-from mcvine.acc import config
-# config.floattype = "float32"
-
 import os
-import histogram.hdf as hh
 import numpy as np
 import pytest
-import shutil
 from collections import deque
 from math import gcd, pow, prod, sqrt
-from mcvine import run_script
 from mcvine.acc import test
 from mcvine.acc.config import get_numpy_floattype
 from mcvine.acc.components.optics.beamstop import Beamstop
@@ -28,55 +22,11 @@ def test_compare_mcvine(className, num_neutrons=int(1e7), debug=False):
     """
     Tests the acc cpu implementation of a slit or beamstop against mcvine
     """
-    if debug:
-        assert num_neutrons < 1001
-    classname = className.lower()
-
-    # Run the mcvine instrument first
-    instr = os.path.join(thisdir, f"{classname}_instrument.py")
-    mcvine_outdir = f"out.debug-mcvine_{classname}_cpu_instrument"
-    if os.path.exists(mcvine_outdir):
-        shutil.rmtree(mcvine_outdir)
-    run_script.run1(
-        instr, mcvine_outdir,
-        ncount=num_neutrons, buffer_size=num_neutrons,
-        factory=f"mcvine.components.optics.{className}",
-        save_neutrons_after=debug,
-        overwrite_datafiles=True)
-
-    # Run our accelerated implementation
-    outdir = f"out.debug-{classname}_gpu_instrument"
-    if os.path.exists(outdir):
-        shutil.rmtree(outdir)
-    run_script.run1(
-        instr, outdir,
-        ncount=num_neutrons, buffer_size=num_neutrons,
-        module=f"mcvine.acc.components.optics.{classname}",
-        save_neutrons_after=debug,
-        overwrite_datafiles=True)
-
-    # Compare output files
-    mcvine_Ixy = hh.load(os.path.join(mcvine_outdir, "Ixy.h5"))
-    mcvine_Ixdivx = hh.load(os.path.join(mcvine_outdir, "Ixdivx.h5"))
-    Ixy = hh.load(os.path.join(outdir, "Ixy.h5"))
-    Ixdivx = hh.load(os.path.join(outdir, "Ixdivx.h5"))
-
-    global interactive
-    if interactive:
-        from histogram import plot as plotHist
-        plotHist(mcvine_Ixy)
-        plotHist(mcvine_Ixdivx)
-        plotHist(Ixy)
-        plotHist(Ixdivx)
-        plotHist((Ixy-mcvine_Ixy)/mcvine_Ixy)
-    assert mcvine_Ixy.shape() == Ixy.shape()
-    assert mcvine_Ixdivx.shape() == Ixdivx.shape()
-
-    tolerance = 1e-7 if get_numpy_floattype() == np.float32 else 1e-25
-    assert np.allclose(mcvine_Ixy.data().storage(), Ixy.data().storage(),
-                       atol=tolerance)
-    assert np.allclose(mcvine_Ixdivx.data().storage(), Ixdivx.data().storage(),
-                       atol=tolerance)
+    import test_helper
+    test_helper.compare_mcvine(className,
+                               ["Ixy", "Ixdivx", "Ixdivy"],
+                               {"float32": 1e-7, "float64": 1e-25},
+                               num_neutrons, debug)
 
 
 @pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')

--- a/tests/components/optics/test_slit_beamstop.py
+++ b/tests/components/optics/test_slit_beamstop.py
@@ -13,12 +13,11 @@ from mcni import neutron_buffer, neutron
 from mcni.neutron_storage import neutrons_as_npyarr
 
 thisdir = os.path.dirname(__file__)
-interactive = False
 
 
 @pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
 @pytest.mark.parametrize("className", ["Slit", "Beamstop"])
-def test_compare_mcvine(className, num_neutrons=int(1e7), debug=False):
+def test_compare_mcvine(className, num_neutrons=int(1e7), debug=False, interactive=False):
     """
     Tests the acc cpu implementation of a slit or beamstop against mcvine
     """
@@ -26,7 +25,7 @@ def test_compare_mcvine(className, num_neutrons=int(1e7), debug=False):
     test_helper.compare_mcvine(className,
                                ["Ixy", "Ixdivx", "Ixdivy"],
                                {"float32": 1e-7, "float64": 1e-25},
-                               num_neutrons, debug)
+                               num_neutrons, debug, interactive=interactive)
 
 
 @pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
@@ -150,17 +149,13 @@ def neutron_buffer_from_array(neutrons):
 
 
 def debug():
-    global interactive
-    interactive = True
-    test_compare_mcvine(debug=True, num_neutrons=100)
+    test_compare_mcvine(debug=True, num_neutrons=100, interactive=True)
     return
 
 
 def main():
-    global interactive
-    interactive = True
     className = "Beamstop"
-    test_compare_mcvine(num_neutrons=int(1e6), className=className)
+    test_compare_mcvine(num_neutrons=int(1e6), className=className, interactive=True)
     return
 
 


### PR DESCRIPTION
Adjusts code for instruments and MCViNE comparison for,

- arm
- beamstop
- guide
- slit

It seemed wise to avoid touching the tapered guide while it remains actively worked on.

This work addresses but does not yet complete #69 because the common helper code will require some flexibility adding to accommodate any special needs of the tapered guide or any other current accelerated instruments. However, that improvement can be provided in subsequent PRs.