### PR TITLE
Buffered run script option

### DIFF
--- a/acc/run_script.py
+++ b/acc/run_script.py
@@ -8,7 +8,8 @@ from .components.StochasticComponentBase import StochasticComponentBase
 
 def run(script, workdir, ncount,
         overwrite_datafiles=True,
-        ntotalthreads=None, threads_per_block=None,
+        ntotalthreads=int(1e6), threads_per_block=512,
+        use_buffer=False,
         **kwds):
     """run a mcvine.acc simulation script on one node. The script must define the instrument.
 
@@ -24,7 +25,13 @@ Parameters:
     os.makedirs(workdir)
     curdir = os.path.abspath(os.curdir)
     compiled_script_path = os.path.join(workdir, 'compiled_mcvine_acc_instrument.py')
-    compiled_script = compile(script, compiled_script=compiled_script_path, **kwds)
+    if use_buffer:
+        compiled_script = compile_buffered(script,
+                                           compiled_script=compiled_script_path,
+                                           **kwds)
+    else:
+        compiled_script = compile(script, compiled_script=compiled_script_path,
+                                  **kwds)
     m = imp.load_source('mcvinesim', compiled_script)
     os.chdir(workdir)
     try:
@@ -78,6 +85,48 @@ Parameters:
     with open(compiled_script, 'wt') as stream:
         stream.write(text)
     return compiled_script
+
+
+def compile_buffered(script, compiled_script=None, **kwds):
+    script = os.path.abspath(script)
+    instrument = loadInstrument(script, **kwds)
+    comps = instrument.components
+    modules = []
+    body = []
+    for i, comp in enumerate(comps):
+        modules.append((comp.__module__, comp.__class__.__name__))
+        prefix = (
+            "rng_states, "
+            if isinstance(comp, StochasticComponentBase)
+            else ""
+        )
+        if i>0:
+            body.append("transform_kernel[nblocks, tpb](neutrons_d, n_neutrons_per_thread, rotmats[{}], offsets[{}])".format(i-1, i-1))
+        body.append("process_kernel{}[nblocks, tpb]({} neutrons_d, n_neutrons_per_thread, args[{}])".format(i, prefix, i))
+        continue
+    module_imports = ['from {} import {} as comp{}'.format(m, c, i) for i, (m, c) in enumerate(modules)]
+    module_imports = '\n'.join(module_imports)
+    propagate_defs = ['process_kernel{} = comp{}.process_kernel'.format(i, i) for i in range(len(comps))]
+    propagate_defs = '\n'.join(propagate_defs)
+    args = [f'args{i}' for i in range(len(comps))]
+    args = ', '.join(args)
+    indent = 4*' '
+    body = '\n'.join([indent+line for line in body])
+    text = compiled_script_template_buffered.format(
+        script = script,
+        module_imports = module_imports,
+        propagate_definitions = propagate_defs,
+        args=args, instrument_body=body
+    )
+    if compiled_script is None:
+        f, ext = os.path.splitext(script)
+        kwds_str = str(kwds)
+        uid = hashlib.sha224(kwds_str.encode("UTF-8")).hexdigest()[:8]
+        compiled_script = f + "_compiled_" + uid + ext
+    with open(compiled_script, 'wt') as stream:
+        stream.write(text)
+    return compiled_script
+
 
 def calcTransformations(instrument):
     """given a mcni.Instrument instance, calculate transformation matrices and
@@ -151,6 +200,89 @@ def run(ncount, ntotalthreads=None, threads_per_block=None, **kwds):
         ncount, ntotalthreads=ntotalthreads, threads_per_block=threads_per_block)
     saveMonitorOutputs(instrument, scale_factor=1.0/ncount)
 """
+
+compiled_script_template_buffered = """#!/usr/bin/env python
+
+script = {script!r}
+from mcvine.acc.run_script import loadInstrument, calcTransformations, saveMonitorOutputs
+
+from numba import cuda
+import numba as nb
+import numpy as np
+import math
+from numba.cuda.random import create_xoroshiro128p_states
+from mcvine.acc.neutron import abs2rel
+from mcvine.acc.config import get_numba_floattype, get_numpy_floattype
+NB_FLOAT = get_numba_floattype()
+
+{module_imports}
+
+{propagate_definitions}
+
+
+@cuda.jit()
+def transform_kernel(neutrons, n_neutrons_per_thread, rotmat, offset):
+    '''
+    Kernel to adjust neutrons between two components
+    '''
+    N = len(neutrons)
+    thread_index = cuda.grid(1)
+    start_index = thread_index*n_neutrons_per_thread
+    end_index = min(start_index+n_neutrons_per_thread, N)
+    r = cuda.local.array(3, dtype=NB_FLOAT)
+    v = cuda.local.array(3, dtype=NB_FLOAT)
+    for i in range(start_index, end_index):
+        neutron = neutrons[i]
+        abs2rel(neutron[:3], neutron[3:6], rotmat, offset, r, v)
+
+
+def instrument_kernel(rng_states, N, n_neutrons_per_thread, nblocks, tpb, args):
+    '''
+    Driver function to run all kernels needed for the instrument
+    '''
+
+    {args}, offsets, rotmats = args
+
+    # Create neutron device buffer
+    neutrons = np.zeros((N, 10), dtype=np.float64)
+    neutrons_d = cuda.to_device(neutrons)
+
+{instrument_body}
+
+    cuda.synchronize()
+
+    #neutrons = neutrons_d.copy_to_host()
+
+
+from mcvine.acc.components.sources.SourceBase import SourceBase
+class InstrumentBase(SourceBase):
+    def __init__(self, instrument):
+        offsets, rotmats = calcTransformations(instrument)
+        self.propagate_params = tuple(c.propagate_params for c in instrument.components)
+        self.propagate_params += (offsets, rotmats)
+        return
+    def propagate(self):
+        pass
+InstrumentBase.process_kernel_no_buffer = instrument_kernel
+
+def run(ncount, ntotalthreads=int(1e6), threads_per_block=512, **kwds):
+    instrument = loadInstrument(script, **kwds)
+
+    ntotthreads = min(ncount, int(ntotalthreads))
+    nblocks = math.ceil(ntotthreads / threads_per_block)
+    actual_nthreads = threads_per_block * nblocks
+    n_neutrons_per_thread = math.ceil(ncount / actual_nthreads)
+    print("%s blocks, %s threads, %s neutrons per thread" % (nblocks, threads_per_block, n_neutrons_per_thread))
+    rng_states = create_xoroshiro128p_states(actual_nthreads, seed=1)
+
+    base = InstrumentBase(instrument)
+
+    instrument_kernel(rng_states, ncount, n_neutrons_per_thread, nblocks, threads_per_block, base.propagate_params)
+    cuda.synchronize()
+
+    saveMonitorOutputs(instrument, scale_factor=1.0/ncount)
+"""
+
 
 def saveMonitorOutputs(instrument, scale_factor=1.0):
     for comp in instrument.components:

--- a/tests/test_run_script.py
+++ b/tests/test_run_script.py
@@ -16,14 +16,23 @@ def test_compile():
     return
 
 @pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
+def test_compile_buffered():
+    run_script.compile_buffered(script)
+    return
+
+@pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
 def test_run():
     run_script.run(script, workdir, ncount=ncount)
     return
 
+@pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
+def test_run_buffered():
+    run_script.run(script, workdir, ncount=int(1e6), use_buffer=True)
+    return
 
 def main():
     test_run()
-    os.system("plothist --min=0 --max=1e-6 {}/divpos.h5".format(workdir))
+    os.system("plothist --min=0 --max=1e-6 {}/posdiv.h5".format(workdir))
     return
 
 if __name__ == '__main__': main()


### PR DESCRIPTION
This adds a `use_buffer` option to `run_script.run` which changes the way an instrument script is compiled. The buffered version launches each component `process` kernel separately rather than one kernel for each component's `propagate`.

This is mainly to help explore different options (refer to #77) for running the instrument to help performance with components like the tapered guide. With this buffered approach, each component can have a different kernel launch configuration, which may help occupancy for particular components or allow for filtering of absorbed neutrons between components.