### PR TITLE
Add CSG box geometry

### DIFF
--- a/tests/geometry/test_box.py
+++ b/tests/geometry/test_box.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import pytest
+import numpy as np
+
+from mcvine.acc import test
+from mcvine.acc.geometry import locate, location
+
+
+# device functions can be tested with CUDASIM only
+@pytest.mark.skipif(not test.USE_CUDASIM, reason='no CUDASIM')
+def test_cu_device_locate_wrt_box():
+    assert locate.cu_device_locate_wrt_box(0, 0, 0, 0.02, 0.03, 0.04) == location.inside
+    assert locate.cu_device_locate_wrt_box(0.01, 0, 0, 0.02, 0.03, 0.04) == location.onborder
+    assert locate.cu_device_locate_wrt_box(0.0101, 0, 0, 0.02, 0.03, 0.04) == location.outside
+
+    return

--- a/tests/geometry/test_box.py
+++ b/tests/geometry/test_box.py
@@ -11,7 +11,20 @@ from mcvine.acc.geometry import locate, location
 @pytest.mark.skipif(not test.USE_CUDASIM, reason='no CUDASIM')
 def test_cu_device_locate_wrt_box():
     assert locate.cu_device_locate_wrt_box(0, 0, 0, 0.02, 0.03, 0.04) == location.inside
+    assert locate.cu_device_locate_wrt_box(0.009, 0, 0, 0.02, 0.03, 0.04) == location.inside
+    assert locate.cu_device_locate_wrt_box(0, 0.0149, 0, 0.02, 0.03, 0.04) == location.inside
+    assert locate.cu_device_locate_wrt_box(0, 0, 0.0199, 0.02, 0.03, 0.04) == location.inside
+    assert locate.cu_device_locate_wrt_box(0.009, 0.0149, 0.0199, 0.02, 0.03, 0.04) == location.inside
+    assert locate.cu_device_locate_wrt_box(-0.009, -0.0149, -0.0199, 0.02, 0.03, 0.04) == location.inside
+
     assert locate.cu_device_locate_wrt_box(0.01, 0, 0, 0.02, 0.03, 0.04) == location.onborder
+    assert locate.cu_device_locate_wrt_box(0, 0.015, 0, 0.02, 0.03, 0.04) == location.onborder
+    assert locate.cu_device_locate_wrt_box(0, 0, 0.02, 0.02, 0.03, 0.04) == location.onborder
+    assert locate.cu_device_locate_wrt_box(0.01, 0.015, 0.02, 0.02, 0.03, 0.04) == location.onborder
+
     assert locate.cu_device_locate_wrt_box(0.0101, 0, 0, 0.02, 0.03, 0.04) == location.outside
+    assert locate.cu_device_locate_wrt_box(0, 0.0201, 0, 0.02, 0.03, 0.04) == location.outside
+    assert locate.cu_device_locate_wrt_box(0, 0, 0.0301, 0.02, 0.03, 0.04) == location.outside
+    assert locate.cu_device_locate_wrt_box(0.0101, 0.0201, 0.0301, 0.02, 0.03, 0.04) == location.outside
 
     return


### PR DESCRIPTION
This implements a `Box` shape to be used in CSG shapes. The `onBox` methods were implemented in both the `locate.py` and `arrow_intersect.py` factory classes.