### PR TITLE
Performance scripts for UN and HMS

### DIFF
--- a/acc/run_script.py
+++ b/acc/run_script.py
@@ -84,8 +84,8 @@ Parameters:
             body.append("{}{}propagate{}({} neutron, *args{})".format(
                 ' '*ms_indent, n_ms, i, prefix, i))
 
-        if comp.is_multiplescattering:
-            # insert a multiple scattering loop
+        if comp.is_multiplescattering and i + 1 < len(comps):
+            # insert a multiple scattering loop for remaining components
             body.append("{}for ms{} in range(num_ms{}):".format(' '*ms_indent, i, i))
             ms_indent += 4
             ms_loop = True

--- a/tests/UN_speed_check.yml
+++ b/tests/UN_speed_check.yml
@@ -1,0 +1,26 @@
+ncounts: [1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9]
+iterations: 2
+output_file: "./un_ms_timings_yml.txt"
+scripts:
+  - name: "cpu"
+    file: "components/samples/UN_speed_instrument.py"
+    kwds: { 
+      use_gpu: false,
+      multiple_scattering: true,
+      Ei: 500.0
+    }
+    acc_run: false
+    skip_for: [1e8, 1e9, 1e10]
+    mpi: true
+    nodes: 1
+
+  - name: "acc"
+    file: "components/samples/UN_speed_instrument.py"
+    kwds: { use_gpu: true,
+            gpu_multiple_scattering: true,
+            Ei: 500.0
+          }
+    acc_run: true
+    skip_for: [ ]
+
+

--- a/tests/check_speed.py
+++ b/tests/check_speed.py
@@ -37,7 +37,7 @@ def run(instrument_script, ncount, niters, mpi=False, nodes=1, acc_run=False, sk
             avg_times.append(np.nan)
             continue
 
-        print(" Running '{}' with n={}".format(instrument_script, n))
+        print(" Running '{}' with n={:1.0e}".format(instrument_script, n))
 
         times = []
         # redirect script output to reduce terminal clutter
@@ -82,6 +82,10 @@ def run(instrument_script, ncount, niters, mpi=False, nodes=1, acc_run=False, sk
             delta = time_after - time_before
             times.append(delta)
 
+            sys.stdout = sys.__stdout__
+            print("\t\t--Time (iter {}) = {} s".format(iter, delta * 1e-9))
+            sys.stdout = stdout
+
         sys.stdout = sys.__stdout__
 
         time_avg = np.sum(np.asarray(times)) / len(times)
@@ -98,7 +102,7 @@ def run(instrument_script, ncount, niters, mpi=False, nodes=1, acc_run=False, sk
 def parse_array_opt(array):
     tmp = array
     if isinstance(array, str):
-        tmp = np.fromstring(array, dtype=np.float, sep=',')
+        tmp = np.fromstring(array, dtype=float, sep=',')
     # convert sci notation number (e.g, 1e5) to int
     output = []
     for n in tmp:

--- a/tests/check_speed.py
+++ b/tests/check_speed.py
@@ -193,7 +193,7 @@ def main():
 
     for i in range(len(ncounts)):
         n = ncounts[i]
-        line = "{}\t".format(n)
+        line = "{:1.0e}\t".format(n)
         for r in runs:
             line += "{:.4f}\t".format(runs[r][i] * 1e-9)
         line += "\n"

--- a/tests/components/samples/UN_speed_instrument.py
+++ b/tests/components/samples/UN_speed_instrument.py
@@ -1,0 +1,44 @@
+import os, sys
+thisdir = os.path.abspath(os.path.dirname(__file__))
+if thisdir not in sys.path: sys.path.insert(0, thisdir)
+import mcvine, mcvine.components as mc
+
+def source(ctor, Ei):
+    return ctor(
+        name = 'src',
+        radius = 0., width = 0.01, height = 0.01, dist = 1.,
+        xw = 0.008, yh = 0.008,
+        E0 = Ei, dE=0.01*Ei, Lambda0=0, dLambda=0.,
+        flux=1, gauss=0
+    )
+source_cpu = lambda Ei: source(mc.sources.Source_simple, Ei)
+from mcvine.acc.components.sources.source_simple import Source_simple
+source_gpu = lambda Ei: source(Source_simple, Ei)
+
+sample_xml=os.path.join(thisdir, "sampleassemblies", "UN", "sampleassembly.xml")
+sample_cpu = lambda: mc.samples.SampleAssemblyFromXml('sample', sample_xml)
+from UN_HMS import HMS
+sample_gpu_MS = lambda: HMS('sample')
+from UN_HSS import HSS
+sample_gpu_SS = lambda: HSS('sample')
+
+def instrument(
+        use_gpu,
+        Ei=500.,
+        gpu_multiple_scattering=True,
+        source_cpu_factory=source_cpu,
+        sample_cpu_factory=sample_cpu,
+        source_gpu_factory=source_gpu,
+):
+    instrument = mcvine.instrument()
+    if use_gpu:
+        instrument.append(source_gpu_factory(Ei), position=(0,0,0))
+        if gpu_multiple_scattering:
+            sample = sample_gpu_MS()
+        else:
+            sample = sample_gpu_SS()
+    else:
+        instrument.append(source_cpu_factory(Ei), position=(0,0,0))
+        sample = sample_cpu_factory()
+    instrument.append(sample, position=(0,0,1.1))
+    return instrument

--- a/tests/components/samples/hms_speed_instrument.py
+++ b/tests/components/samples/hms_speed_instrument.py
@@ -1,0 +1,41 @@
+import os, sys
+thisdir = os.path.abspath(os.path.dirname(__file__))
+if thisdir not in sys.path: sys.path.insert(0, thisdir)
+import mcvine, mcvine.components as mc
+
+def source(ctor, Ei):
+    return ctor(
+        name = 'src',
+        radius = 0., width = 0.01, height = 0.01, dist = 1.,
+        xw = 0.008, yh = 0.008,
+        E0 = Ei, dE=0.01*Ei, Lambda0=0, dLambda=0.,
+        flux=1, gauss=0
+    )
+source_cpu = lambda Ei: source(mc.sources.Source_simple, Ei)
+from mcvine.acc.components.sources.source_simple import Source_simple
+source_gpu = lambda Ei: source(Source_simple, Ei)
+
+sample_xml=os.path.join(thisdir, "sampleassemblies", "isotropic_hollowcylinder", "sampleassembly.xml")
+sample_cpu = lambda: mc.samples.SampleAssemblyFromXml('sample', sample_xml)
+from HMS_isotropic_hollowcylinder import HMS
+sample_gpu = lambda: HMS('sample')
+
+def instrument(
+        use_gpu,
+        Ei=500.,
+        source_cpu_factory=source_cpu,
+        sample_cpu_factory=sample_cpu,
+        source_gpu_factory=source_gpu,
+        sample_gpu_factory=sample_gpu,
+        z_sample=2.0
+):
+    instrument = mcvine.instrument()
+    if use_gpu:
+        instrument.append(source_gpu_factory(Ei), position=(0, 0, 0))
+        sample = sample_gpu_factory()
+        instrument.append(sample, position=(0, 0, z_sample))
+    else:
+        instrument.append(source_cpu_factory(Ei), position=(0, 0, 0))
+        sample = sample_cpu_factory()
+        instrument.append(sample, position=(0, 0, z_sample))
+    return instrument

--- a/tests/components/samples/sampleassemblies/isotropic_hollowcylinder/sample-scatterer.xml
+++ b/tests/components/samples/sampleassemblies/isotropic_hollowcylinder/sample-scatterer.xml
@@ -3,7 +3,8 @@
 <!DOCTYPE scatterer>
 
 <!-- weights: absorption, scattering, transmission -->
-<homogeneous_scatterer mcweights="0, 1, 0">
+<homogeneous_scatterer mcweights="0, 1, 0"
+    max_multiplescattering_loops="3">
   <IsotropicKernel absorption_coefficient="10./m" scattering_coefficient="10./m">
   </IsotropicKernel>
 </homogeneous_scatterer>

--- a/tests/components/samples/sampleassemblies/isotropic_hollowcylinder/sampleassembly.xml
+++ b/tests/components/samples/sampleassemblies/isotropic_hollowcylinder/sampleassembly.xml
@@ -2,7 +2,10 @@
 
 <!DOCTYPE SampleAssembly>
 
-<SampleAssembly name="isotropic_hollowcylinder">
+<SampleAssembly name="isotropic_hollowcylinder"
+    max_multiplescattering_loops_among_scatterers="1"
+    max_multiplescattering_loops_interactM_path1="3"
+    min_neutron_probability="1e-20">
   <PowderSample name="sample" type="sample">
     <Shape>
       <difference>

--- a/tests/hms_speed_check.yml
+++ b/tests/hms_speed_check.yml
@@ -1,0 +1,33 @@
+ncounts: [1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9]
+iterations: 2
+output_file: "./hms_timings.txt"
+scripts:
+  - name: "cpu"
+    file: "components/samples/hms_speed_instrument.py"
+    kwds: { 
+      use_gpu: false,
+      multiple_scattering: true,
+      Ei: 500.0
+    }
+    acc_run: false
+    skip_for: [1e8, 1e9, 1e10]
+
+  - name: "mpi_12core"
+    file: "components/samples/hms_speed_instrument.py"
+    kwds: { 
+      use_gpu: false,
+      multiple_scattering: true,
+      Ei: 500.0
+    }
+    acc_run: false
+    skip_for: [1e8, 1e9, 1e10]
+    mpi: true
+    nodes: 12
+
+  - name: "acc"
+    file: "components/samples/hms_speed_instrument.py"
+    kwds: { use_gpu: true,
+            Ei: 500.0
+          }
+    acc_run: true
+    skip_for: [ ]


### PR DESCRIPTION
This adds simple instruments and `check_speed.py` configurations used to check the performance of the HMS hollow cylinder and UN against the CPU version of mcvine.
