### PR TITLE
add method `applyTransformation` and use it in "compiled" instrument script

### DIFF
--- a/acc/neutron.py
+++ b/acc/neutron.py
@@ -20,6 +20,7 @@ def abs2rel(r, v, rotmat, offset, rtmp, vtmp):
     vec3.copy(r, rtmp); vec3.copy(v, vtmp)
     vec3.abs2rel(rtmp, rotmat, offset, r)
     vec3.mXv(rotmat, vtmp, v)
+applyTransformation = abs2rel
 
 @cuda.jit(void(NB_FLOAT[:]),
           device=True, inline=True)

--- a/acc/run_script.py
+++ b/acc/run_script.py
@@ -72,14 +72,14 @@ Parameters:
         if ms_loop:
             # TODO: fix for > 1 MS components
             if i>0:
-                line = "{}abs2rel(out_neutrons[ms{}][:3], out_neutrons[ms{}][3:6], rotmats[{}], offsets[{}], r, v)".format(' '*ms_indent, ms_loop_ind, ms_loop_ind, i-1, i-1)
+                line = "{}applyTransformation(out_neutrons[ms{}][:3], out_neutrons[ms{}][3:6], rotmats[{}], offsets[{}], r, v)".format(' '*ms_indent, ms_loop_ind, ms_loop_ind, i-1, i-1)
                 body.append(line)
             line = "{}propagate{}({} out_neutrons[ms{}], *args{})".format(
                 ' '*ms_indent, i, prefix, ms_loop_ind, i)
             body.append(line)
         else:
             if i>0:
-                body.append("{}abs2rel(neutron[:3], neutron[3:6], rotmats[{}], offsets[{}], r, v)".format(' '*ms_indent, i-1, i-1))
+                body.append("{}applyTransformation(neutron[:3], neutron[3:6], rotmats[{}], offsets[{}], r, v)".format(' '*ms_indent, i-1, i-1))
             n_ms = f'num_ms{i} = ' if comp.is_multiplescattering else ''
             body.append("{}{}propagate{}({} neutron, *args{})".format(
                 ' '*ms_indent, n_ms, i, prefix, i))
@@ -170,7 +170,7 @@ from mcvine.acc.run_script import loadInstrument, calcTransformations, saveMonit
 from numba import cuda
 import numpy as np, numba as nb
 from numba.cuda.random import create_xoroshiro128p_states
-from mcvine.acc.neutron import abs2rel
+from mcvine.acc.neutron import applyTransformation
 from mcvine.acc.config import get_numba_floattype, get_numpy_floattype
 NB_FLOAT = get_numba_floattype()
 
@@ -227,7 +227,7 @@ from mcvine.acc.run_script import loadInstrument, calcTransformations, saveMonit
 from numba import cuda
 import numpy as np, numba as nb
 from numba.cuda.random import create_xoroshiro128p_states
-from mcvine.acc.neutron import abs2rel
+from mcvine.acc.neutron import applyTransformation
 from mcvine.acc.config import get_numba_floattype, get_numpy_floattype
 NB_FLOAT = get_numba_floattype()
 

--- a/tests/test_coord_transform_among_comps.py
+++ b/tests/test_coord_transform_among_comps.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import os, numpy as np, pytest
+thisdir = os.path.abspath(os.path.dirname(__file__))
+import mcvine
+from mcvine.acc import test
+from mcvine.acc.components.optics.arm import Arm
+from mcvine.acc.run_script import calcTransformations
+from mcvine.acc.neutron import abs2rel
+
+def createInstrument():
+    instrument = mcvine.instrument()
+    comp1 = Arm('comp1')
+    instrument.append(comp1, position=(0,0,0.))
+    comp2 = Arm('comp2')
+    instrument.append(comp2, position=(0,0,1.))
+    comp3 = Arm('comp3')
+    instrument.append(comp3, position=(0,0,0.), orientation=(0, 90, 0), relativeTo=comp2)
+    comp4 = Arm('comp4')
+    instrument.append(comp4, position=(0,0,1.), orientation=(0, 0, 90), relativeTo=comp2)
+    return instrument
+
+@pytest.mark.skipif(not test.USE_CUDASIM, reason='No CUDASIM')
+def test():
+    instrument = createInstrument()
+    offsets, rotmats = calcTransformations(instrument)
+    tmp_position = np.array([0., 0., 0.])
+    tmp_velocity = np.array([0., 0., 0.])
+    # translation only
+    position = np.array([0., 0., 0.])
+    velocity = np.array([0., 0., 1.])
+    abs2rel(position, velocity, rotmats[0], offsets[0], tmp_position, tmp_velocity)
+    assert np.allclose(position, [0,0,-1])
+    assert np.allclose(velocity, [0,0,1])
+    # rotation only
+    position = np.array([0., 0., -1.])
+    velocity = np.array([0., 0., 1.])
+    abs2rel(position, velocity, rotmats[1], offsets[1], tmp_position, tmp_velocity)
+    assert np.allclose(position, [1,0,0])
+    assert np.allclose(velocity, [-1,0,0])
+    # translation and rotation
+    position = np.array([0., 0., 0])
+    velocity = np.array([0., 0., 1.])
+    abs2rel(position, velocity, rotmats[2], offsets[2], tmp_position, tmp_velocity)
+    assert np.allclose(position, [0,0,-1])
+    assert np.allclose(velocity, [0,-1,0])
+    return

--- a/tests/test_coord_transform_among_comps.py
+++ b/tests/test_coord_transform_among_comps.py
@@ -8,7 +8,7 @@ from mcvine.acc.components.optics.arm import Arm
 from mcvine.acc.run_script import calcTransformations
 from mcvine.acc.neutron import abs2rel
 
-def createInstrument():
+def createTestInstrument():
     instrument = mcvine.instrument()
     comp1 = Arm('comp1')
     instrument.append(comp1, position=(0,0,0.))
@@ -22,23 +22,25 @@ def createInstrument():
 
 @pytest.mark.skipif(not test.USE_CUDASIM, reason='No CUDASIM')
 def test():
-    instrument = createInstrument()
+    instrument = createTestInstrument()
     offsets, rotmats = calcTransformations(instrument)
+    assert len(rotmats) == len(offsets) == len(instrument.components)-1
+    # tmp arrays required by abs2rel
     tmp_position = np.array([0., 0., 0.])
     tmp_velocity = np.array([0., 0., 0.])
-    # translation only
+    # translation only between comp1 and comp2
     position = np.array([0., 0., 0.])
     velocity = np.array([0., 0., 1.])
     abs2rel(position, velocity, rotmats[0], offsets[0], tmp_position, tmp_velocity)
     assert np.allclose(position, [0,0,-1])
     assert np.allclose(velocity, [0,0,1])
-    # rotation only
+    # rotation only between comp2 and comp3
     position = np.array([0., 0., -1.])
     velocity = np.array([0., 0., 1.])
     abs2rel(position, velocity, rotmats[1], offsets[1], tmp_position, tmp_velocity)
     assert np.allclose(position, [1,0,0])
     assert np.allclose(velocity, [-1,0,0])
-    # translation and rotation
+    # translation and rotation between comp3 and comp4 (indirectly thru comp2)
     position = np.array([0., 0., 0])
     velocity = np.array([0., 0., 1.])
     abs2rel(position, velocity, rotmats[2], offsets[2], tmp_position, tmp_velocity)

--- a/tests/test_coord_transform_among_comps.py
+++ b/tests/test_coord_transform_among_comps.py
@@ -6,7 +6,7 @@ import mcvine
 from mcvine.acc import test
 from mcvine.acc.components.optics.arm import Arm
 from mcvine.acc.run_script import calcTransformations
-from mcvine.acc.neutron import abs2rel
+from mcvine.acc.neutron import applyTransformation
 
 def createTestInstrument():
     instrument = mcvine.instrument()
@@ -25,25 +25,25 @@ def test():
     instrument = createTestInstrument()
     offsets, rotmats = calcTransformations(instrument)
     assert len(rotmats) == len(offsets) == len(instrument.components)-1
-    # tmp arrays required by abs2rel
+    # tmp arrays required by applyTransformation
     tmp_position = np.array([0., 0., 0.])
     tmp_velocity = np.array([0., 0., 0.])
     # translation only between comp1 and comp2
     position = np.array([0., 0., 0.])
     velocity = np.array([0., 0., 1.])
-    abs2rel(position, velocity, rotmats[0], offsets[0], tmp_position, tmp_velocity)
+    applyTransformation(position, velocity, rotmats[0], offsets[0], tmp_position, tmp_velocity)
     assert np.allclose(position, [0,0,-1])
     assert np.allclose(velocity, [0,0,1])
     # rotation only between comp2 and comp3
     position = np.array([0., 0., -1.])
     velocity = np.array([0., 0., 1.])
-    abs2rel(position, velocity, rotmats[1], offsets[1], tmp_position, tmp_velocity)
+    applyTransformation(position, velocity, rotmats[1], offsets[1], tmp_position, tmp_velocity)
     assert np.allclose(position, [1,0,0])
     assert np.allclose(velocity, [-1,0,0])
     # translation and rotation between comp3 and comp4 (indirectly thru comp2)
     position = np.array([0., 0., 0])
     velocity = np.array([0., 0., 1.])
-    abs2rel(position, velocity, rotmats[2], offsets[2], tmp_position, tmp_velocity)
+    applyTransformation(position, velocity, rotmats[2], offsets[2], tmp_position, tmp_velocity)
     assert np.allclose(position, [0,0,-1])
     assert np.allclose(velocity, [0,-1,0])
     return

--- a/tests/test_coord_transform_among_comps.py
+++ b/tests/test_coord_transform_among_comps.py
@@ -18,6 +18,8 @@ def createTestInstrument():
     instrument.append(comp3, position=(0,0,0.), orientation=(0, 90, 0), relativeTo=comp2)
     comp4 = Arm('comp4')
     instrument.append(comp4, position=(0,0,1.), orientation=(0, 0, 90), relativeTo=comp2)
+    comp5 = Arm('comp5')
+    instrument.append(comp5, position=(1,0,0.), orientation=(90, 0, 0), relativeTo=comp4)
     return instrument
 
 @pytest.mark.skipif(not test.USE_CUDASIM, reason='No CUDASIM')
@@ -46,4 +48,10 @@ def test():
     applyTransformation(position, velocity, rotmats[2], offsets[2], tmp_position, tmp_velocity)
     assert np.allclose(position, [0,0,-1])
     assert np.allclose(velocity, [0,-1,0])
+    # translation and rotation between comp4 and comp5
+    position = np.array([0., 1., 0])
+    velocity = np.array([0., 0., 1.])
+    applyTransformation(position, velocity, rotmats[3], offsets[3], tmp_position, tmp_velocity)
+    assert np.allclose(position, [-1,0,-1])
+    assert np.allclose(velocity, [0,1,0])
     return


### PR DESCRIPTION
In current implementation, the coordinate transformation from one component to the next is done with method `abs2rel`, which is confusing. Should make an alias method `applyTransformation` and use that.