### PR TITLE
Updates to SANS kernel and add HDF5 loading

### DIFF
--- a/acc/kernels/SANS2D_ongrid.py
+++ b/acc/kernels/SANS2D_ongrid.py
@@ -53,13 +53,14 @@ def S(threadindex, rng_states, neutron, S_QxQy, nx, ny, Qx_min, Qx_max, Qy_min, 
     neutron[-1] *= prob
     return
 
-def makeS(S_QxQy, Qx_min, Qx_max, Qy_min, Qy_max):
-    S_QxQy = np.ascontiguousarray(S_QxQy)
+def makeS(S_QxQy_in, Qx_min, Qx_max, Qy_min, Qy_max):
+    S_QxQy = np.ascontiguousarray(np.transpose(S_QxQy_in))
+
     device_S_QxQy = cuda.to_device(S_QxQy)
     nx, ny = S_QxQy.shape
     @cuda.jit(device=True, inline=True)
     def _S(threadindex, rng_states, neutron):
-        S(threadindex, rng_states, neutron, device_S_QxQy,nx,ny, Qx_min, Qx_max, Qy_min, Qy_max)
+        S(threadindex, rng_states, neutron, device_S_QxQy, nx, ny, Qx_min, Qx_max, Qy_min, Qy_max)
     return _S
 
 from mccomponents.homogeneous_scatterer.Kernel import Kernel

--- a/acc/kernels/xml/parser/SANS2D_ongrid_Kernel.py
+++ b/acc/kernels/xml/parser/SANS2D_ongrid_Kernel.py
@@ -12,8 +12,22 @@ class SANS2D_ongrid_Kernel(base):
         Qx_max = self._parse( kwds['Qx_max'] )
         Qy_min = self._parse( kwds['Qy_min'] )
         Qy_max = self._parse( kwds['Qy_max'] )
-        import numpy as np
-        S_QxQy = np.load( kwds['S_QxQy'] )
+
+        # check if S_QxQy is a .npy or .h5 file
+        if kwds['S_QxQy'].endswith(".npy"):
+            import numpy as np
+            S_QxQy = np.load( kwds['S_QxQy'] )
+        elif kwds['S_QxQy'].endswith(".h5"):
+            import h5py
+            input_file = h5py.File(kwds['S_QxQy'], 'r')
+            # Load the intensity dataset "I" from file
+            if "I" not in input_file.keys():
+                raise RuntimeError("Error loading intensity from S_QxQy file, could not find dataset 'I'")
+            S_QxQy = input_file["I"][()]
+            input_file.close()
+        else:
+            raise RuntimeError("Unrecognized file type for S_QxQy. Expected .npy or .h5")
+
         from ...SANS2D_ongrid import SANS2D_ongrid_Kernel as f
         return f(S_QxQy, Qx_min, Qx_max, Qy_min, Qy_max)
 

--- a/tests/components/samples/sans2d_grid_instrument.py
+++ b/tests/components/samples/sans2d_grid_instrument.py
@@ -11,7 +11,8 @@ def instrument(
 ):
     instrument = mcvine.instrument()
 
-    source = mc.sources.Source_simple(
+    from mcvine.acc.components.sources.source_simple import Source_simple
+    source = Source_simple(
         'source',
         radius = 0, height = 0.0003, width = 0.0003,
         dist = source2sample-0.1,
@@ -26,10 +27,11 @@ def instrument(
     sample = HSS('sample')
     instrument.append(sample, position=(0,0,source2sample))
 
-    Ixy = mc.monitors.PSD_monitor(
+    from mcvine.acc.components.monitors.psd_monitor import PSD_monitor
+    Ixy = PSD_monitor(
         'Ixy',
         nx = 250, ny = 250,
-        filename = "Ixy.dat",
+        filename = "Ixy.h5",
         xmin = -0.075, xmax = 0.075,
         ymin = -0.075, ymax = 0.075,
     )

--- a/tests/components/samples/test_sans2d_grid.py
+++ b/tests/components/samples/test_sans2d_grid.py
@@ -3,7 +3,7 @@
 import os, shutil
 import pytest
 from mcvine.acc import test
-from mcvine import run_script
+from mcvine.acc import run_script
 
 thisdir = os.path.dirname(__file__)
 
@@ -15,7 +15,7 @@ def test1():
     outdir = 'out.sans2d_grid'
     if os.path.exists(outdir): shutil.rmtree(outdir)
     ncount = 2e6
-    run_script.run1(
+    run_script.run(
         instr, outdir,
         ncount=ncount, buffer_size=int(ncount),
     )


### PR DESCRIPTION
This is a minor update to the SANS 2D kernel to transpose the input data and adds the ability to use an `.h5` file in the XML sample assembly.