### PR TITLE
Guide anyshape gravity

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
       - name: install / build
         shell: pwsh
         run: |
-          conda install pytest pytest-cov coveralls openmpi mcvine-core=1.4.9
+          conda install pytest pytest-cov coveralls openmpi mcvine-core=1.4.12
           python -c "import matplotlib; import mantid"
           mcvine
           conda install numba=0.53.1 cupy cudatoolkit=11.2.2
@@ -89,7 +89,7 @@ jobs:
           conda remove -n testenv --all
           conda create -n testenv python=${{ matrix.python-version }}
           conda activate testenv
-          conda install pytest pytest-cov coveralls openmpi mcvine-core=1.4.9
+          conda install pytest pytest-cov coveralls openmpi mcvine-core=1.4.12
           python -c "import matplotlib"
           mcvine
           conda install numba=0.53.1 cupy cudatoolkit=11.2.2

--- a/acc/components/optics/geometry2d.py
+++ b/acc/components/optics/geometry2d.py
@@ -2,23 +2,32 @@
 #
 
 import numpy as np
-from math import sqrt
+from math import sqrt, fabs
 from numba import cuda, void
 
 from ...config import get_numba_floattype
 NB_FLOAT = get_numba_floattype()
 
-
+# modified from
 # https://stackoverflow.com/questions/1119627/how-to-test-if-a-point-is-inside-of-a-convex-polygon-in-2d-integer-coordinates#:~:text=If%20it%20is%20convex%2C%20a,traversed%20in%20the%20same%20order)
 @cuda.jit(device=True)
 def inside_convex_polygon(point, vertices):
-    previous_side = get_side(v_sub(vertices[1], vertices[0]), v_sub(point, vertices[0]))
+    # previous_side = get_side(v_sub(vertices[1], vertices[0]), v_sub(point, vertices[0]))
+    previous_sign = cosine_sign(v_sub(vertices[1], vertices[0]), v_sub(point, vertices[0]))
+    previous_side = previous_sign <= 0
     n_vertices = len(vertices)
     for n in range(1, n_vertices):
         a, b = vertices[n], vertices[(n+1)%n_vertices]
         affine_segment = v_sub(b, a)
         affine_point = v_sub(point, a)
-        current_side = get_side(affine_segment, affine_point)
+        sign = cosine_sign(affine_segment, affine_point)
+        if fabs(sign) < 1E-14:
+            continue
+        # current_side = get_side(affine_segment, affine_point)
+        current_side = sign <= 0
+        if fabs(previous_sign) < 1E-14:
+            previous_side = current_side
+            continue
         if previous_side != current_side:
             return False
     return True

--- a/acc/components/optics/guide_anyshape_gravity.py
+++ b/acc/components/optics/guide_anyshape_gravity.py
@@ -1,0 +1,197 @@
+# -*- python -*-
+#
+
+from math import sqrt, fabs
+import numpy as np, numba
+from numba import cuda, void
+from mcni.utils.conversion import V2K
+
+category = 'optics'
+
+from ...config import get_numba_floattype
+NB_FLOAT = get_numba_floattype()
+from ._guide_utils import calc_reflectivity
+from ...neutron import absorb
+from ...geometry._utils import insert_into_sorted_list_with_indexes
+from .geometry2d import inside_convex_polygon
+from ... import vec3
+
+max_bounces = 1000
+max_numfaces = 100
+
+
+from .guide_anyshape import calc_face_normal, get_faces_data
+
+@cuda.jit(NB_FLOAT(NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:], NB_FLOAT[:, :],  NB_FLOAT[:]),
+          device=True, inline=True)
+def intersect_plane(position, velocity, center, plane_unitvecs, rtmp):
+    vec3.subtract(center, position, rtmp)
+    normal = plane_unitvecs[2, :]
+    dist = vec3.dot(rtmp, normal)
+    vtmp = vec3.dot(velocity, normal)
+    return dist/vtmp
+
+@cuda.jit(
+    void(
+        NB_FLOAT[:],
+        NB_FLOAT[:, :, :], NB_FLOAT[:, :], NB_FLOAT[:, :, :], NB_FLOAT[:, :, :],
+        NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+        NB_FLOAT[:], NB_FLOAT[:], numba.int32[:],
+        NB_FLOAT[:],
+    ), device=True
+)
+def _propagate(
+        in_neutron,
+        faces, centers, unitvecs, faces2d,
+        R0, Qc, alpha, m, W,
+        tmp1, intersections, face_indexes,
+        gravity,
+):
+    nfaces = len(faces)
+    for nb in range(max_bounces):
+        # calc intersection with each face and save positive ones in a list with increasing order
+        ninter = 0
+        for iface in range(nfaces):
+            intersection = intersect_plane(
+                in_neutron[:3], in_neutron[3:6],
+                centers[iface], unitvecs[iface],
+                tmp1
+            )
+            if intersection>0:
+                ninter = insert_into_sorted_list_with_indexes(iface, intersection, face_indexes, intersections, ninter) 
+        if not ninter:
+            break
+        # find the smallest intersection that is inside the mirror 
+        found = False
+        for iinter in range(ninter):
+            face_index = face_indexes[iinter]
+            intersection = intersections[iinter]
+            # calc position of intersection
+            vec3.copy(in_neutron[3:6], tmp1)
+            vec3.scale(tmp1, intersection)
+            vec3.add(tmp1, in_neutron[:3], tmp1)
+            # calc 2d coordinates and use it to check if it is inside the mirror
+            vec3.subtract(tmp1, centers[face_index], tmp1)
+            e0 = unitvecs[face_index, 0, :]
+            e1 = unitvecs[face_index, 1, :]
+            e2 = unitvecs[face_index, 2, :]
+            face2d = faces2d[face_index]
+            if inside_convex_polygon((vec3.dot(tmp1, e0), vec3.dot(tmp1, e1)), face2d):
+                found = True
+                break
+        if not found:
+            break
+        x, y, z, vx, vy, vz = in_neutron[:6]
+        t = in_neutron[-2]
+        prob = in_neutron[-1]
+        # propagate to intersection
+        intersection -= intersection * 1E-14
+        x += vx * intersection
+        y += vy * intersection
+        z += vz * intersection
+        t += intersection
+        #
+        vq = -vec3.dot(in_neutron[3:6], e2)*2
+        R = calc_reflectivity(fabs(vq)*V2K, R0, Qc, alpha, m, W)
+        prob *= R
+        if prob <= 0:
+            absorb(in_neutron)
+            break
+        # tmp1 = velocity change vector
+        vec3.copy(e2, tmp1)
+        vec3.scale(tmp1, vq)
+        # change direction
+        vec3.add(in_neutron[3:6], tmp1, in_neutron[3:6])
+        in_neutron[:3] = x, y, z
+        in_neutron[-2] = t
+        in_neutron[-1] = prob
+    return
+
+from ..ComponentBase import ComponentBase
+class Guide_anyshape_gravity(ComponentBase):
+
+    def __init__(
+            self,
+            name,
+            xwidth=0, yheight=0, zdepth=0, center=False,
+            R0=0.99, Qc=0.0219, alpha=3, m=2, W=0.003,
+            geometry="",
+            **kwargs):
+        """
+        Initialize this Guide component.
+        The guide is centered on the z-axis with the entrance at z=0.
+
+        Parameters:
+        name (str): the name of this component
+        xwidth (m): resize the bounding box on X axis
+        yheight (m): resize the bounding box on y axis
+        zdepth (m): resize the bounding box on z axis
+        center (boolean): object will be centered w.r.t. the local coord system if true
+
+        R0: low-angle reflectivity
+        Qc: critical scattering vector
+        alpha: slope of reflectivity
+        m: m-value of material (0 is complete absorption)
+        W: width of supermirror cutoff
+
+        geometry (str): path of the OFF/PLY geometry file for the guide shape
+        """
+        self.name = name
+        faces, centers, unitvecs, faces2d = get_faces_data(geometry, xwidth, yheight, zdepth, center)
+        faces2d = np.array([
+            [
+                [np.dot(vertex-center, ex), np.dot(vertex-center, ey)]
+                for vertex in face
+            ]
+            for face, center, (ex,ey,ez) in zip(faces, centers, unitvecs)
+        ]) # nfaces, nverticesperface, 2
+        self.propagate_params = (
+            faces, centers, unitvecs, faces2d,
+            float(R0), float(Qc), float(alpha), float(m), float(W),
+        )
+        return
+    
+    @property
+    def gravity(self):
+        return self._gravity
+    
+    @gravity.setter
+    def gravity(self, g):
+        print("set my gravity to", g)
+        self._gravity = g
+        self.propagate_params = self.propagate_params + (g,)
+
+    @property
+    def abs_orientation(self):
+        return self._abs_orientation
+    
+    @abs_orientation.setter
+    def abs_orientation(self, orientation):
+        self._abs_orientation = orientation
+        self.gravity = np.dot(orientation, [0, -1, 0])
+
+    @cuda.jit(
+        void(
+            NB_FLOAT[:],
+            NB_FLOAT[:, :, :], NB_FLOAT[:, :], NB_FLOAT[:, :, :], NB_FLOAT[:, :, :],
+            NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT, NB_FLOAT,
+            NB_FLOAT[:]
+        ), device=True, inline=True,
+    )
+    def propagate(
+            in_neutron,
+            faces, centers, unitvecs, faces2d,
+            R0, Qc, alpha, m, W,
+            g,
+    ):
+        tmp1 = cuda.local.array(3, dtype=numba.float64)
+        nfaces = len(faces)
+        assert nfaces < max_numfaces
+        intersections = cuda.local.array(max_numfaces, dtype=numba.float64)
+        face_indexes = cuda.local.array(max_numfaces, dtype=numba.int32)
+        return _propagate(
+            in_neutron, faces, centers, unitvecs, faces2d,
+            R0, Qc, alpha, m, W,
+            tmp1, intersections, face_indexes,
+            g,
+        )

--- a/acc/test/compare_acc_nonacc.py
+++ b/acc/test/compare_acc_nonacc.py
@@ -49,8 +49,8 @@ def compare_acc_nonacc(
     # the {classname}_instrument.py implements "is_acc" kwd correctly.
     nonacc_component_spec = nonacc_component_spec or dict(
         factory=f"mcvine.components.optics.{className}",
-        is_acc = False,
     )
+    nonacc_component_spec['is_acc'] = False
     run_script.run1(
         instr, mcvine_outdir,
         ncount=num_neutrons, buffer_size=num_neutrons,
@@ -64,8 +64,8 @@ def compare_acc_nonacc(
         shutil.rmtree(outdir)
     acc_component_spec = acc_component_spec or dict(
         module=f"mcvine.acc.components.optics.{classname}",
-        is_acc = True,
     )
+    acc_component_spec['is_acc'] = True
     run_script.run1(
         instr, outdir,
         ncount=num_neutrons, buffer_size=num_neutrons,

--- a/acc/test/instrument_factory.py
+++ b/acc/test/instrument_factory.py
@@ -28,6 +28,8 @@ class InstrumentBuilder:
 
     def __init__(self):
         self.instrument = mcvine.instrument()
+        self.origin = mc.optics.Arm('origin')
+        self.instrument.append(self.origin, position=[0,0,0])
         self.z = 0.
 
     @classmethod
@@ -67,8 +69,12 @@ class InstrumentBuilder:
         gap (float): how much space along z to leave between this and the next
         is_rotated (bool): if to rotate this instrument in positioning it
         """
-        self.instrument.append(component, position=(0., 0., self.z),
-                               orientation=(0., 0., 90. if is_rotated else 0.))
+        self.instrument.append(
+            component,
+            position=(0., 0., self.z),
+            orientation=(0., 0., 90. if is_rotated else 0.),
+            relativeTo=self.origin,
+        )
         self.z += gap
 
 def construct(
@@ -88,7 +94,7 @@ def construct(
     save_neutrons_after (bool): if to save neutrons after the given optics
     """
     builder = InstrumentBuilder() if builder is None else builder
-
+    
     # source
     builder.add(builder.get_source(), gap=gap)
 

--- a/tests/components/optics/guide_anyshape_example1_instrument.py
+++ b/tests/components/optics/guide_anyshape_example1_instrument.py
@@ -5,18 +5,20 @@ from instrument_factory import construct
 
 thisdir = os.path.dirname(__file__)
 
-def instrument(is_acc=False, geometry=None, dims=None, acc_component_factory=None):
+def instrument(
+        is_acc=False, geometry=None, dims=None,
+        acc_component_factory=None,
+        nonacc_component_factory=None,
+    ):
     guide_length = 10.
     if is_acc:
         geometry = geometry or os.path.join(thisdir, './data/guide_anyshape_straight_3.5cmX3.5cmX10m.off')
         if acc_component_factory is None:
-            from mcvine.acc.components.optics.guide_anyshape import Guide_anyshape as acc_component_factory
+            from mcvine.acc.components.optics.guide_anyshape import Guide_anyshape as factory
         else:
-            import importlib
-            module = '.'.join(acc_component_factory.split('.')[:-1])
-            mod = importlib.import_module(module)
-            acc_component_factory = getattr(mod, acc_component_factory.split('.')[-1])
-        target = acc_component_factory(
+            factory = _import_factory(acc_component_factory)
+        print(factory)
+        target = factory(
             name='guide',
             xwidth=0, yheight=0, zdepth=0,
             center=False,
@@ -25,7 +27,11 @@ def instrument(is_acc=False, geometry=None, dims=None, acc_component_factory=Non
         )
     else:
         import mcvine.components
-        factory = mcvine.components.optics.Guide
+        if nonacc_component_factory is None:
+            factory = nonacc_component_factory or mcvine.components.optics.Guide
+        else:
+            factory = eval(nonacc_component_factory)
+        print(factory)
         if dims is None:
             dims = dict(
                 w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=guide_length,
@@ -33,6 +39,14 @@ def instrument(is_acc=False, geometry=None, dims=None, acc_component_factory=Non
         target = factory(
             name='guide',
             R0=0.99, Qc=0.0219, alpha=6.07, m=3, W=0.003,
+            G = 9.80665,
             **dims,
         )
     return construct(target, guide_length)
+
+def _import_factory(factory):
+    import importlib
+    module = '.'.join(factory.split('.')[:-1])
+    mod = importlib.import_module(module)
+    return getattr(mod, factory.split('.')[-1])
+ 

--- a/tests/components/optics/guide_anyshape_example1_instrument.py
+++ b/tests/components/optics/guide_anyshape_example1_instrument.py
@@ -6,9 +6,10 @@ from instrument_factory import construct
 thisdir = os.path.dirname(__file__)
 
 def instrument(
-        is_acc=False, geometry=None, dims=None,
+        is_acc=False, geometry=None,
         acc_component_factory=None,
         nonacc_component_factory=None,
+        nonacc_component_kargs=None,
     ):
     guide_length = 10.
     if is_acc:
@@ -17,7 +18,6 @@ def instrument(
             from mcvine.acc.components.optics.guide_anyshape import Guide_anyshape as factory
         else:
             factory = _import_factory(acc_component_factory)
-        print(factory)
         target = factory(
             name='guide',
             xwidth=0, yheight=0, zdepth=0,
@@ -31,16 +31,13 @@ def instrument(
             factory = nonacc_component_factory or mcvine.components.optics.Guide
         else:
             factory = eval(nonacc_component_factory)
-        print(factory)
-        if dims is None:
-            dims = dict(
-                w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=guide_length,
-            )
+        nonacc_component_kargs = nonacc_component_kargs or dict(
+            w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=guide_length,
+        )
         target = factory(
             name='guide',
             R0=0.99, Qc=0.0219, alpha=6.07, m=3, W=0.003,
-            G = 9.80665,
-            **dims,
+            **nonacc_component_kargs
         )
     return construct(target, guide_length)
 

--- a/tests/components/optics/guide_anyshape_example1_instrument.py
+++ b/tests/components/optics/guide_anyshape_example1_instrument.py
@@ -5,12 +5,18 @@ from instrument_factory import construct
 
 thisdir = os.path.dirname(__file__)
 
-def instrument(is_acc=False, geometry=None, dims=None):
+def instrument(is_acc=False, geometry=None, dims=None, acc_component_factory=None):
     guide_length = 10.
     if is_acc:
         geometry = geometry or os.path.join(thisdir, './data/guide_anyshape_straight_3.5cmX3.5cmX10m.off')
-        from mcvine.acc.components.optics.guide_anyshape import Guide_anyshape
-        target = Guide_anyshape(
+        if acc_component_factory is None:
+            from mcvine.acc.components.optics.guide_anyshape import Guide_anyshape as acc_component_factory
+        else:
+            import importlib
+            module = '.'.join(acc_component_factory.split('.')[:-1])
+            mod = importlib.import_module(module)
+            acc_component_factory = getattr(mod, acc_component_factory.split('.')[-1])
+        target = acc_component_factory(
             name='guide',
             xwidth=0, yheight=0, zdepth=0,
             center=False,

--- a/tests/components/optics/test_guide_anyshape_exampl1.py
+++ b/tests/components/optics/test_guide_anyshape_exampl1.py
@@ -26,7 +26,7 @@ def test_compare_mcvine2(num_neutrons=int(1e7), debug=False, interactive=False):
     Tests the acc cpu implementation of a straight guide against mcvine
     """
     geometry = os.path.join(thisdir, './data/guide_anyshape_straight_3.5cmX3.5cmX10mX4cmX4cm.off')
-    dims = dict(
+    nonacc_component_kargs = dict(
         w1=0.035, h1=0.035, w2=0.04, h2=0.04, l=10,
     )
     from mcvine.acc.test.compare_acc_nonacc import compare_acc_nonacc
@@ -36,8 +36,8 @@ def test_compare_mcvine2(num_neutrons=int(1e7), debug=False, interactive=False):
         {"float32": 1e-6, "float64": 1e-7},
         num_neutrons, debug,
         interactive=interactive, workdir = thisdir,
-        acc_component_spec=dict(geometry=geometry, is_acc=True),
-        nonacc_component_spec=dict(dims=dims, is_acc=False),
+        acc_component_spec=dict(geometry=geometry),
+        nonacc_component_spec=dict(nonacc_component_kargs=nonacc_component_kargs),
     )
 
 def debug():
@@ -46,7 +46,7 @@ def debug():
 
 
 def main():
-    test_compare_mcvine2(num_neutrons=int(1e6), interactive=True)
+    test_compare_mcvine(num_neutrons=int(1e6), interactive=True)
     return
 
 

--- a/tests/components/optics/test_guide_anyshape_gravity.py
+++ b/tests/components/optics/test_guide_anyshape_gravity.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+import os
+import numpy as np
+import pytest
+
+from mcvine.acc.components.optics import guide_anyshape
+from mcvine.acc import test
+
+thisdir = os.path.dirname(__file__)
+
+@pytest.mark.skipif(not test.USE_CUDASIM, reason='no CUDASIM')
+def test_propagate():
+    in_neutron = np.array([
+        0, 0.01, -20,
+        0, -1, 2000,
+        0, 0,
+        0, 1,
+    ])
+    faces = np.array([[
+        [-1, 0, -1],
+        [-1, 0, 1],
+        [1, 0, 1],
+        [1, 0, -1],
+    ]])
+    centers = np.array([
+        [0,0,0]
+    ])
+    unitvecs = np.array([[
+        [0, 0, 1],
+        [1, 0, 0],
+        [0, 1, 0],
+    ]])
+    R0=0.99; Qc=0.0219; alpha=3; m=2; W=0.003
+    faces2d = np.array([[
+        [-1, -1],
+        [-1, 1],
+        [1, 1],
+        [1, -1],
+    ]])
+    tmp1 = np.zeros(3)
+    nfaces = len(faces)
+    intersections = np.zeros(nfaces, dtype=np.float64)
+    face_indexes = np.zeros(nfaces, dtype=np.int)
+    guide_anyshape._propagate(
+        in_neutron,
+        faces, centers, unitvecs, faces2d,
+        R0, Qc, alpha, m, W,
+        tmp1, intersections, face_indexes
+    )
+    assert np.allclose(
+        in_neutron,
+        [
+            0, 0, 0,
+            0, 1, 2000,
+            0, 0,
+            0.01,
+            0.99
+        ]
+    )
+    return
+
+@pytest.mark.skipif(not test.USE_CUDASIM, reason='no CUDASIM')
+def test_propagate2():
+    geometry=os.path.join(thisdir, './data/guide_anyshape_straight_3.5cmX3.5cmX10m.off')
+    faces, centers, unitvecs, faces2d = guide_anyshape.get_faces_data(geometry, xwidth=0, yheight=0, zdepth=0, center=False)
+    R0=0.99; Qc=0.0219; alpha=3; m=2; W=0.003
+    tmp1 = np.zeros(3)
+    nfaces = len(faces)
+    intersections = np.zeros(nfaces, dtype=np.float64)
+    face_indexes = np.zeros(nfaces, dtype=np.int)
+    neutron = np.array([
+        0, 0, -1,
+        0, 0.035/2*1000, 1*1000+1E-10,
+        0, 0,
+        0, 1,
+    ])
+    guide_anyshape._propagate(
+        neutron,
+        faces, centers, unitvecs, faces2d,
+        R0, Qc, alpha, m, W,
+        tmp1, intersections, face_indexes
+    )
+    # print(neutron)
+    assert np.allclose(
+        neutron[:-1],
+        [
+            0, 0.0175, 8,
+            0, -17.5, 1000,
+            0, 0,
+            0.009,
+        ]
+    )
+    assert neutron[-1] < 5E-18 # 4.78366558e-18]
+    return

--- a/tests/components/optics/test_guide_anyshape_gravity.py
+++ b/tests/components/optics/test_guide_anyshape_gravity.py
@@ -4,16 +4,35 @@ import os
 import numpy as np
 import pytest
 
-from mcvine.acc.components.optics import guide_anyshape
+from mcvine.acc.components.optics import guide_anyshape_gravity
 from mcvine.acc import test
 
 thisdir = os.path.dirname(__file__)
 
 @pytest.mark.skipif(not test.USE_CUDASIM, reason='no CUDASIM')
-def test_propagate():
-    in_neutron = np.array([
+def test_intersect():
+    neutron = np.array([
         0, 0.01, -20,
         0, -1, 2000,
+        0, 0,
+        0, 1,
+    ])
+    gravity = np.array([0, -9.8, 0])
+    center = np.array([0,0,0])
+    normal = np.array([0,1,0])
+    t = guide_anyshape_gravity.intersect_plane(
+        neutron[:3], neutron[3:6], gravity,
+        center, normal
+    )
+    assert np.isclose(t, 0.009552841750957684)
+    return
+
+@pytest.mark.skipif(not test.USE_CUDASIM, reason='no CUDASIM')
+def test_propagate():
+    gravity = np.array([0, -9.8, 0])
+    in_neutron = np.array([
+        0, -0.01, -20,
+        0, 4, 8000,
         0, 0,
         0, 1,
     ])
@@ -39,57 +58,25 @@ def test_propagate():
         [1, -1],
     ]])
     tmp1 = np.zeros(3)
+    tmp2 = np.zeros(3)
+    tmp3 = np.zeros(3)
     nfaces = len(faces)
     intersections = np.zeros(nfaces, dtype=np.float64)
     face_indexes = np.zeros(nfaces, dtype=np.int)
-    guide_anyshape._propagate(
+    guide_anyshape_gravity._propagate(
         in_neutron,
         faces, centers, unitvecs, faces2d,
         R0, Qc, alpha, m, W,
-        tmp1, intersections, face_indexes
+        intersections, face_indexes, gravity,
+        tmp1, tmp2, tmp3,
     )
     assert np.allclose(
         in_neutron,
         [
-            0, 0, 0,
-            0, 1, 2000,
+            0., 0., 6.16280534e-02,
+            0., -3.97542451, 8000,
             0, 0,
-            0.01,
-            0.99
+            2.50770351e-03, 0.99
         ]
     )
-    return
-
-@pytest.mark.skipif(not test.USE_CUDASIM, reason='no CUDASIM')
-def test_propagate2():
-    geometry=os.path.join(thisdir, './data/guide_anyshape_straight_3.5cmX3.5cmX10m.off')
-    faces, centers, unitvecs, faces2d = guide_anyshape.get_faces_data(geometry, xwidth=0, yheight=0, zdepth=0, center=False)
-    R0=0.99; Qc=0.0219; alpha=3; m=2; W=0.003
-    tmp1 = np.zeros(3)
-    nfaces = len(faces)
-    intersections = np.zeros(nfaces, dtype=np.float64)
-    face_indexes = np.zeros(nfaces, dtype=np.int)
-    neutron = np.array([
-        0, 0, -1,
-        0, 0.035/2*1000, 1*1000+1E-10,
-        0, 0,
-        0, 1,
-    ])
-    guide_anyshape._propagate(
-        neutron,
-        faces, centers, unitvecs, faces2d,
-        R0, Qc, alpha, m, W,
-        tmp1, intersections, face_indexes
-    )
-    # print(neutron)
-    assert np.allclose(
-        neutron[:-1],
-        [
-            0, 0.0175, 8,
-            0, -17.5, 1000,
-            0, 0,
-            0.009,
-        ]
-    )
-    assert neutron[-1] < 5E-18 # 4.78366558e-18]
     return

--- a/tests/components/optics/test_guide_anyshape_gravity_example1.py
+++ b/tests/components/optics/test_guide_anyshape_gravity_example1.py
@@ -15,7 +15,7 @@ def test_compare_mcvine(num_neutrons=int(1e7), debug=False, interactive=False):
     compare_acc_nonacc(
         "guide_anyshape_example1", # {}_instrument.py will be the instrument script
         ["Ixy", "Ixdivx", "Ixdivy"],
-        {"float32": 1e-6, "float64": 1e-7},
+        {"float32": 1e-4, "float64": 1e-5},
         num_neutrons, debug,
         interactive=interactive, workdir = thisdir,
         acc_component_spec=dict(

--- a/tests/components/optics/test_guide_anyshape_gravity_example1.py
+++ b/tests/components/optics/test_guide_anyshape_gravity_example1.py
@@ -19,8 +19,10 @@ def test_compare_mcvine(num_neutrons=int(1e7), debug=False, interactive=False):
         num_neutrons, debug,
         interactive=interactive, workdir = thisdir,
         acc_component_spec=dict(
-            is_acc=True,
             acc_component_factory = 'mcvine.acc.components.optics.guide_anyshape_gravity.Guide_anyshape_gravity',
+        ),
+        nonacc_component_spec=dict(
+            nonacc_component_factory = 'mcvine.components.optics.Guide_gravity',
         )
     )
 

--- a/tests/components/optics/test_guide_anyshape_gravity_example1.py
+++ b/tests/components/optics/test_guide_anyshape_gravity_example1.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+import os
+import pytest
+from mcvine.acc import test
+
+thisdir = os.path.dirname(__file__)
+
+@pytest.mark.skipif(not test.USE_CUDA, reason='No CUDA')
+def test_compare_mcvine(num_neutrons=int(1e7), debug=False, interactive=False):
+    """
+    Tests the acc cpu implementation of a straight guide against mcvine
+    """
+    from mcvine.acc.test.compare_acc_nonacc import compare_acc_nonacc
+    compare_acc_nonacc(
+        "guide_anyshape_example1", # {}_instrument.py will be the instrument script
+        ["Ixy", "Ixdivx", "Ixdivy"],
+        {"float32": 1e-6, "float64": 1e-7},
+        num_neutrons, debug,
+        interactive=interactive, workdir = thisdir,
+        acc_component_spec=dict(
+            is_acc=True,
+            acc_component_factory = 'mcvine.acc.components.optics.guide_anyshape_gravity.Guide_anyshape_gravity',
+        )
+    )
+
+def debug():
+    test_compare_mcvine(debug=True, num_neutrons=100, interactive=True)
+    return
+
+
+def main():
+    test_compare_mcvine(num_neutrons=int(1e6), interactive=True)
+    return
+
+
+if __name__ == '__main__':
+    main()
+    # debug()

--- a/tests/components/optics/test_guide_anyshape_gravity_example1.py
+++ b/tests/components/optics/test_guide_anyshape_gravity_example1.py
@@ -15,7 +15,7 @@ def test_compare_mcvine(num_neutrons=int(1e7), debug=False, interactive=False):
     compare_acc_nonacc(
         "guide_anyshape_example1", # {}_instrument.py will be the instrument script
         ["Ixy", "Ixdivx", "Ixdivy"],
-        {"float32": 1e-4, "float64": 1e-5},
+        {"float32": 1e-6, "float64": 1e-7},
         num_neutrons, debug,
         interactive=interactive, workdir = thisdir,
         acc_component_spec=dict(
@@ -23,6 +23,10 @@ def test_compare_mcvine(num_neutrons=int(1e7), debug=False, interactive=False):
         ),
         nonacc_component_spec=dict(
             nonacc_component_factory = 'mcvine.components.optics.Guide_gravity',
+            nonacc_component_kargs = dict(
+                G = -9.80665,
+                w1=0.035, h1=0.035, w2=0.035, h2=0.035, l=10,
+            )
         )
     )
 


### PR DESCRIPTION
This is a new component, guide_anyshape with gravity effect. This is an extension of guide_anyshape component without gravity #127. It only works with mcvine-core >= 1.4.12

Tested with a simple straight guide geometry against the mcstas Guide_gravity component. Agreement was pretty good.

Here is a comparison for one of the more interesting monitor data:

Non-acc y divy (mcstas Guide_gravity)
![nonacc_ydivy](https://github.com/mcvine/acc/assets/1796155/6da54c53-fc36-4b8f-814e-d12516bd4dbb)
acc y divy (mcvine acc guide_anyshape_gravity)
![acc_ydivy](https://github.com/mcvine/acc/assets/1796155/b7fc53eb-ff48-408e-8d48-bfc2a4525a3c)
